### PR TITLE
Add assign operator for CGradientBoostVectorSetStatistics

### DIFF
--- a/NeoML/src/TraditionalML/GradientBoostVectorSetStatistics.h
+++ b/NeoML/src/TraditionalML/GradientBoostVectorSetStatistics.h
@@ -22,6 +22,7 @@ class CGradientBoostVectorSetStatistics {
 public:
 	CGradientBoostVectorSetStatistics();
 	explicit CGradientBoostVectorSetStatistics( const CGradientBoostVectorSetStatistics& other );
+	CGradientBoostVectorSetStatistics& operator=( const CGradientBoostVectorSetStatistics& other );
 
 	// Adds a vector
 	void Add( double gradient, double hessian, float weight );
@@ -64,6 +65,16 @@ inline CGradientBoostVectorSetStatistics::CGradientBoostVectorSetStatistics( con
 	totalHessian( other.totalHessian ),
 	totalWeight( other.totalWeight )
 {
+}
+
+inline CGradientBoostVectorSetStatistics& CGradientBoostVectorSetStatistics::operator=( const CGradientBoostVectorSetStatistics& other )
+{
+	if( &other != this ) {
+		totalGradient = other.totalGradient;
+		totalHessian = other.totalHessian;
+		totalWeight = other.totalWeight;
+	}
+	return *this;
 }
 
 inline void CGradientBoostVectorSetStatistics::Add( double gradient, double hessian, float weight )


### PR DESCRIPTION
in order to avoid `-Wdeprecated-copy` warning on gcc-9

Signed-off-by: Valeriy Fedyunin <valery.fedyunin@abbyy.com>