### PR TITLE
Auto discover bias parameters for LAMB-solver.

### DIFF
--- a/NeoML/include/NeoML/Dnn/Dnn.h
+++ b/NeoML/include/NeoML/Dnn/Dnn.h
@@ -254,6 +254,9 @@ protected:
 	// Fills with zeros the parameters that are less (but not equal) than a given threshold
 	virtual void FilterLayerParams( float /*threshold*/ ) {}
 
+	// Indexes of trainable bias parameters for LAMB solver.
+	virtual void GetFreeTermParameterIndexes( CArray<int>& indexes ) const { indexes.DeleteAll(); }
+
 	// Retrieves the reference to the IMathEngine with which the layer was created
 	IMathEngine& MathEngine() const;
 
@@ -374,6 +377,7 @@ private:
 	friend class CDnn;
 	friend class CDnnLayerGraph;
 	friend class CDnnSolver;
+	friend class CDnnLambGradientSolver;
 };
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/NeoML/include/NeoML/Dnn/DnnSolver.h
+++ b/NeoML/include/NeoML/Dnn/DnnSolver.h
@@ -388,21 +388,6 @@ class NEOML_API CDnnLambGradientSolver : public CDnnSolver {
 public:
 	explicit CDnnLambGradientSolver( IMathEngine& mathEngine );
 
-	// Match type used when checking if layer is excluded from weightDecay
-	enum TExcludeLayerNameMatchType {
-		// Exact match with given string
-		ELNMT_Exact,
-		// If layer's name contains given string
-		ELNMT_Include
-	};
-
-	// Exclude layer from weightDecay optimization
-	// layerName - layer name (or substring if ELMNT_Include is used)
-	// type - match type
-	// paramIndex - index of optimized layer parameter to exclude (NotFound means all layer parameters)
-	void ExcludeWeightDecayLayer( const char* layerName, TExcludeLayerNameMatchType type = ELNMT_Exact,
-		int paramIndex = NotFound );
-
 	// Gets/set moment decay rate (weighted sum of previous gradients)
 	// By default is equal to 0.9 
 	float GetMomentDecayRate() const { return momentDecayRate; }
@@ -491,23 +476,11 @@ private:
 	CArray<float> layersGradientNormSquare;
 	float totalGradientNorm;
 
-	// Layer excluded from optimization
-	struct CExcludedLayer {
-		// Layer name (or substring)
-		CString LayerName;
-		// Match type (exact or substring)
-		TExcludeLayerNameMatchType MatchType;
-		// Parameter number
-		// -1 if all parameters
-		int ParamIndex;
-
-		CExcludedLayer() : MatchType( ELNMT_Exact ), ParamIndex( NotFound ) {}
-	};
-	// Layers excluded from weight decay
-	CArray<CExcludedLayer> excludedLayers;
+	// Layer excluded from optimization (backward compatibility)
+	struct CExcludedLayer;
 
 	float calcL2Norm( const CConstFloatHandle& data, int dataSize ) const;
-	void getWeightDecayIndices( const CBaseLayer& layer, int paramsCount, CHashTable<int>& indexes ) const;
+	void getBiasIndices( const CBaseLayer& layer, CHashTable<int>& indexes ) const;
 
 	void calcNormalizeMultiplier( const CDnnBlob& weights, const CDnnBlob& update, const CFloatHandle& multiplier ) const;
 };

--- a/NeoML/include/NeoML/Dnn/DnnSolver.h
+++ b/NeoML/include/NeoML/Dnn/DnnSolver.h
@@ -413,6 +413,10 @@ public:
 	bool UseTrustRatio() const { return useTrustRatio; }
 	void SetUseTrustRatio( bool value ) { useTrustRatio = value; }
 
+	// By default weight decay is not applied to bias params and normalizaion layers.
+	bool UseWeightDecayForBias() const { return useWeightDecayForBias; }
+	void SetUseWeightDecayForBias( bool value ) { useWeightDecayForBias = value; }
+
 	// Use NVLamb modification
 	// https://medium.com/nvidia-ai/a-guide-to-optimizer-implementation-for-bert-at-scale-8338cc7f45fd
 	// By default is false
@@ -450,6 +454,8 @@ private:
 	float weightDecayClip;
 	// Is LAMB normalization used
 	bool useTrustRatio;
+	// Is LAMB appliedToBias
+	bool useWeightDecayForBias;
 	// Is NVLamb modification used
 	bool useNvLamb;
 

--- a/NeoML/include/NeoML/Dnn/Layers/BatchNormalizationLayer.h
+++ b/NeoML/include/NeoML/Dnn/Layers/BatchNormalizationLayer.h
@@ -63,6 +63,7 @@ protected:
 	void RunOnce() override;
 	void BackwardOnce() override;
 	void LearnOnce() override;
+	void GetFreeTermParameterIndexes( CArray<int>& indexes ) const override;
 
 private:
 	bool isChannelBased;

--- a/NeoML/include/NeoML/Dnn/Layers/ConvLayer.h
+++ b/NeoML/include/NeoML/Dnn/Layers/ConvLayer.h
@@ -98,6 +98,7 @@ protected:
 	// The filter; the pointer is valid only when the desired parameters are known: either set externally or are filled in on reshape
 	CPtr<CDnnBlob>& Filter() { return paramBlobs[0]; }
 	CPtr<CDnnBlob>& FreeTerms() { return paramBlobs[1]; }	// free terms matrix
+	void GetFreeTermParameterIndexes( CArray<int>& indexes ) const override;
 
 	CPtr<CDnnBlob>& FilterDiff() { return paramDiffBlobs[0]; }
 	CPtr<CDnnBlob>& FreeTermsDiff() { return paramDiffBlobs[1]; }

--- a/NeoML/include/NeoML/Dnn/Layers/FullyConnectedLayer.h
+++ b/NeoML/include/NeoML/Dnn/Layers/FullyConnectedLayer.h
@@ -62,6 +62,7 @@ protected:
 	void BackwardOnce() override;
 	void LearnOnce() override;
 	void FilterLayerParams( float threshold ) override;
+	void GetFreeTermParameterIndexes( CArray<int>& indexes ) const override;
 
 	// The filter. The pointer is valid only if the desired parameters are known (either defined externally or obtained on reshape)
 	CPtr<CDnnBlob>& Weights() { return paramBlobs[0]; }

--- a/NeoML/include/NeoML/Dnn/Layers/ObjectNormalizationLayer.h
+++ b/NeoML/include/NeoML/Dnn/Layers/ObjectNormalizationLayer.h
@@ -58,6 +58,7 @@ protected:
 	void RunOnce() override;
 	void BackwardOnce() override;
 	void LearnOnce() override;
+	void GetFreeTermParameterIndexes( CArray<int>& indexes ) const override;
 
 private:
 	CPtr<CDnnBlob> epsilon;

--- a/NeoML/include/NeoML/Dnn/Layers/TimeConvLayer.h
+++ b/NeoML/include/NeoML/Dnn/Layers/TimeConvLayer.h
@@ -75,6 +75,7 @@ protected:
 	void BackwardOnce() override;
 	void LearnOnce() override;
 	void FilterLayerParams( float threshold ) override;
+	void GetFreeTermParameterIndexes( CArray<int>& indexes ) const override;
 
 private:
 	CTimeConvolutionDesc* desc;

--- a/NeoML/src/Dnn/Layers/BaseConvLayer.cpp
+++ b/NeoML/src/Dnn/Layers/BaseConvLayer.cpp
@@ -142,6 +142,15 @@ void CBaseConvLayer::SetFreeTermData(const CPtr<CDnnBlob>& newFreeTerms)
 	}
 }
 
+void CBaseConvLayer::GetFreeTermParameterIndexes( CArray<int>& indexes ) const
+{
+	indexes.DeleteAll();
+	if ( !IsZeroFreeTerm() ) {
+		indexes.Add( 1 );
+	}
+	
+}
+
 void CBaseConvLayer::ApplyBatchNormalization(CBatchNormalizationLayer& batchNorm)
 {
 	CPtr<CDnnBlob> params = batchNorm.GetFinalParams();

--- a/NeoML/src/Dnn/Layers/BatchNormalizationLayer.cpp
+++ b/NeoML/src/Dnn/Layers/BatchNormalizationLayer.cpp
@@ -449,7 +449,6 @@ void CBatchNormalizationLayer::LearnOnce()
 void CBatchNormalizationLayer::GetFreeTermParameterIndexes( CArray<int>& indexes ) const
 {
 	indexes.DeleteAll();
-#pragma message ("Unsure about batch norm params (they are packed altogether in one blob).")
 	indexes.Add( 0 );
 }
 

--- a/NeoML/src/Dnn/Layers/BatchNormalizationLayer.cpp
+++ b/NeoML/src/Dnn/Layers/BatchNormalizationLayer.cpp
@@ -446,6 +446,13 @@ void CBatchNormalizationLayer::LearnOnce()
 	isFinalParamDirty = true;
 }
 
+void CBatchNormalizationLayer::GetFreeTermParameterIndexes( CArray<int>& indexes ) const
+{
+	indexes.DeleteAll();
+#pragma message ("Unsure about batch norm params (they are packed altogether in one blob).")
+	indexes.Add( 0 );
+}
+
 void CBatchNormalizationLayer::SetFinalParams(const CPtr<CDnnBlob>& _params)
 {
 	if(finalParams != 0) {

--- a/NeoML/src/Dnn/Layers/FullyConnectedLayer.cpp
+++ b/NeoML/src/Dnn/Layers/FullyConnectedLayer.cpp
@@ -126,6 +126,15 @@ void CFullyConnectedLayer::FilterLayerParams( float threshold )
 	}
 }
 
+void CFullyConnectedLayer::GetFreeTermParameterIndexes( CArray<int>& indexes ) const
+{
+	indexes.DeleteAll();
+	if ( !isZeroFreeTerm ) {
+		indexes.Add( 1 ); // free term index
+	}
+	
+}
+
 void CFullyConnectedLayer::SetNumberOfElements(int newNumberOfElements)
 {
 	NeoAssert( ( Weights() == 0 && FreeTerms() == 0 ) || numberOfElements == newNumberOfElements );

--- a/NeoML/src/Dnn/Layers/ObjectNormalizationLayer.cpp
+++ b/NeoML/src/Dnn/Layers/ObjectNormalizationLayer.cpp
@@ -305,6 +305,15 @@ void CObjectNormalizationLayer::LearnOnce()
 	MathEngine().SumMatrixRowsAdd( 1, ScaleDiff()->GetData(), outDiff, objectCount, objectSize );
 }
 
+void CObjectNormalizationLayer::GetFreeTermParameterIndexes( CArray<int>& indexes ) const
+{
+	indexes.DeleteAll();
+	for (int i = 0; i < PN_Count; i++) {
+		indexes.Add( i );
+	}
+}
+
+
 CLayerWrapper<CObjectNormalizationLayer> ObjectNormalization( float epsilon )
 {
 	return CLayerWrapper<CObjectNormalizationLayer>( "ObjectNormalization", [=]( CObjectNormalizationLayer* result ) {

--- a/NeoML/src/Dnn/Layers/TimeConvLayer.cpp
+++ b/NeoML/src/Dnn/Layers/TimeConvLayer.cpp
@@ -197,6 +197,12 @@ void CTimeConvLayer::FilterLayerParams( float threshold )
 	}
 }
 
+void CTimeConvLayer::GetFreeTermParameterIndexes( CArray<int>& indexes ) const
+{
+	indexes.DeleteAll();
+	indexes.Add( 1 );
+}
+
 void CTimeConvLayer::initDesc()
 {
 	if( desc == 0 && !inputBlobs.IsEmpty() && !outputBlobs.IsEmpty() ) {


### PR DESCRIPTION
Using of LAMB solver is highly error prone because of requirement to manually add bias parameter indexes by layer name.
This PR moves this action to particular layers with bias parameters.

@masepi, please check it for correctness.