### PR TITLE
Use less misleading flag name for TF32 math mode

### DIFF
--- a/NeoMathEngine/include/NeoMathEngine/NeoMathEngine.h
+++ b/NeoMathEngine/include/NeoMathEngine/NeoMathEngine.h
@@ -853,9 +853,9 @@ NEOMATHENGINE_API void CpuMathEngineCleanUp();
 // Half tensor core math - less accurate, supported by all cards with tensor cores
 // Incompatible with float math flag below
 const int GpuMathEngineCublasUseTensorCoresHalfFlag = 0x1;
-// Float tensor core math - more accurate, supported by modern cards (e.g. not supported by TITAN RTX)
+// TF32 tensor core math - more accurate, supported by modern cards based on the Ampere architecture
 // Incompatible with half math flag above
-const int GpuMathEngineCublasUseTensorCoresFloatFlag = 0x2;
+const int GpuMathEngineCublasUseTensorCoresTF32Flag = 0x2;
 
 // Creates a math engine that uses the recommended GPU for calculations
 // Returns null if no GPUs are available

--- a/NeoMathEngine/src/GPU/CUDA/CudaMathEngine.cu
+++ b/NeoMathEngine/src/GPU/CUDA/CudaMathEngine.cu
@@ -56,7 +56,7 @@ CCudaMathEngine::CCudaMathEngine( const CCusparse* _cusparse, const CCublas* _cu
 	// Cublas.
 	ASSERT_CUBLAS( cublas->Create( &cublasHandle ) );
 	cublasMath_t cublasMath = CUBLAS_DEFAULT_MATH;
-	if( ( flags & GpuMathEngineCublasUseTensorCoresFloatFlag ) != 0 ) {
+	if( ( flags & GpuMathEngineCublasUseTensorCoresTF32Flag ) != 0 ) {
 		cublasMath = CUBLAS_TF32_TENSOR_OP_MATH;
 	} else if( ( flags & GpuMathEngineCublasUseTensorCoresHalfFlag ) != 0 ) {
 		cublasMath = CUBLAS_TENSOR_OP_MATH;


### PR DESCRIPTION
Tensor cores don't support regular single-precision float format.
TF32 is more compact and less precise than FP32 (regular single-precision float), but the flag name suggested otherwise.
Also clarified what exactly "modern cards" means.