### PR TITLE
Time conv learn CUDA optimization

### DIFF
--- a/NeoMathEngine/src/GPU/CUDA/CudaMathEngineDnnTimeConv.cu
+++ b/NeoMathEngine/src/GPU/CUDA/CudaMathEngineDnnTimeConv.cu
@@ -201,8 +201,7 @@ void CCudaMathEngine::BlobTimeConvolutionLearnAdd( const CTimeConvolutionDesc& c
 	} else {
 		int matrixRowIndex = 0;
 		CFloatHandle currOutputDiff = outputDiffData;
-		const int widthNorm = ( tempMatrixWidth + BuildTempMatrixCombine - 1 ) / BuildTempMatrixCombine;
-		CFloatHandleStackVar tempMatrixPart( mathEngine(), maxInMemoryHeight * tempMatrixHeight );
+		CFloatHandleStackVar tempMatrixPart( mathEngine(), maxInMemoryHeight * tempMatrixWidth );
 		const int filterCount = desc.Result.ObjectSize();
 
 		// Build temp matrix part by part and add filterDiff of that part
@@ -211,10 +210,10 @@ void CCudaMathEngine::BlobTimeConvolutionLearnAdd( const CTimeConvolutionDesc& c
 
 			dim3 blockCount;
 			dim3 threadCount;
-			getCudaTaskGrid2D( blockCount, threadCount, currPartHeight, widthNorm );
+			getCudaTaskGrid2D( blockCount, threadCount, currPartHeight, tempMatrixWidth );
 
 			BuildTempMatrixKernel<<<blockCount, threadCount>>>( desc, GetRaw( inputData ), currPartHeight,
-				tempMatrixWidth, GetRaw( tempMatrixPart.GetHandle() ), matrixRowIndex, widthNorm );
+				tempMatrixWidth, GetRaw( tempMatrixPart.GetHandle() ), matrixRowIndex );
 
 			MultiplyTransposedMatrixByMatrixAndAdd( currOutputDiff, currPartHeight, filterCount, filterCount,
 				tempMatrixPart.GetHandle(), tempMatrixWidth, tempMatrixWidth, filterDiffData, tempMatrixWidth, tempMatrixWidth );

--- a/NeoMathEngine/src/GPU/CUDA/CudaMathEngineDnnTimeConv.cu
+++ b/NeoMathEngine/src/GPU/CUDA/CudaMathEngineDnnTimeConv.cu
@@ -185,8 +185,10 @@ void CCudaMathEngine::BlobTimeConvolutionLearnAdd( const CTimeConvolutionDesc& c
 
 	// Train the filter
 	if( filterDiff.Height() == 1 && desc.Stride == 1 ) {
+		// This assert has already been checked in InitTimeConvolution
+		ASSERT_EXPR( desc.PaddingFront == 0 && desc.PaddingBack == 0 );
 		// Trivial case
-		MultiplyTransposedMatrixByMatrixAndAdd( outputDiffData + desc.PaddingFront * outputDiff.ObjectSize(), desc.Source.ObjectCount(),
+		MultiplyTransposedMatrixByMatrixAndAdd( outputDiffData, desc.Source.ObjectCount(),
 			outputDiff.ObjectSize(), outputDiff.ObjectSize(), inputData, desc.Source.ObjectSize(),
 			desc.Source.ObjectSize(), filterDiffData, filterDiff.ObjectSize(), filterDiff.BlobSize() );
 	} else {

--- a/NeoMathEngine/src/GPU/CUDA/CudaMathEngineDnnTimeConv.cu
+++ b/NeoMathEngine/src/GPU/CUDA/CudaMathEngineDnnTimeConv.cu
@@ -188,6 +188,7 @@ void CCudaMathEngine::BlobTimeConvolutionLearnAdd( const CTimeConvolutionDesc& c
 	// Let's try to build temp matrix
 	const int tempMatrixWidth = filterDiff.ObjectSize();
 	const int tempMatrixHeight = outputDiff.BlobSize() / filterDiff.ObjectCount();
+	// Max amount of memory allowed is a half of math engine's free memory
 	const int maxInMemoryHeight = min( static_cast<int>( GetFreeMemorySize() / 2 / ( sizeof( float ) * tempMatrixWidth ) ),
 		tempMatrixHeight );
 

--- a/NeoMathEngine/src/GPU/CUDA/Kernels/CudaDnnTimeConvKernels.h
+++ b/NeoMathEngine/src/GPU/CUDA/Kernels/CudaDnnTimeConvKernels.h
@@ -21,7 +21,7 @@ limitations under the License.
 namespace NeoML {
 
 // Time convolution may be done as a matrix multiplication if inputData will be reordered in a temporary matrix
-// where i-th row contains data, which will be processed by filter in roder to get i-th row of output
+// where i-th row contains data, which will be covered by filter in i-th row of output
 
 // This kernel builds a PART of this matrix, starting with firstLineIndex and of matrixHeight height
 // It's done because full temp matrix may require a lot of memory

--- a/NeoMathEngine/test/src/learn/BlobTimeConvolutionLearnAddTest.cpp
+++ b/NeoMathEngine/test/src/learn/BlobTimeConvolutionLearnAddTest.cpp
@@ -380,6 +380,18 @@ INSTANTIATE_TEST_CASE_P( CBlobTimeConvolutionLearnAddTestInstantiation, CBlobTim
 			"PaddingBack = (0 .. 3);"
 			"Dilation = (1 .. 5);"
 			"TestCount = 30"
+		),
+		CTestParams(
+			"BatchLength = 3;"
+			"BatchSize = 15;"
+			"ObjectSize = 3;"
+			"FilterSize = 1;"
+			"FilterCount = 7;"
+			"Stride = 1;"
+			"PaddingFront = 2;"
+			"PaddingBack = 3;"
+			"Dilation = 1;"
+			"TestCount = 1"
 		)
 	)
 );


### PR DESCRIPTION
Now using temporary matrix (split in a way to fit into free memory).

If matrix can't be created, then it uses naive slow kernel (without additional memory consumption).