### PR TITLE
Allow NeoML layer macros outside of namespace NeoML

### DIFF
--- a/NeoML/include/NeoML/Dnn/Dnn.h
+++ b/NeoML/include/NeoML/Dnn/Dnn.h
@@ -25,19 +25,19 @@ limitations under the License.
 #include <stdint.h>
 #include <NeoML/Dnn/DnnLambdaHolder.h>
 
-namespace NeoML {
-
 // The macros for the internal name of a NeoML layer
 // If this macros is used when declaring a class, that class may be registered as a NeoML layer
-#define NEOML_DNN_LAYER( className ) friend class CLayerClassRegistrar< className >;
+#define NEOML_DNN_LAYER( className ) friend class NeoML::CLayerClassRegistrar< className >;
 
 // Registers the class as a NeoML layer
-#define REGISTER_NEOML_LAYER( classType, name ) static CLayerClassRegistrar< classType > __merge__1( _RegisterLayer, __LINE__ )( name, 0 );
-#define REGISTER_NEOML_LAYER_EX( classType, name1, name2 ) static CLayerClassRegistrar< classType > __merge__1( _RegisterLayer, __LINE__ )( name1, name2 );
+#define REGISTER_NEOML_LAYER( classType, name ) static NeoML::CLayerClassRegistrar< classType > __merge__1( _RegisterLayer, __LINE__ )( name, 0 );
+#define REGISTER_NEOML_LAYER_EX( classType, name1, name2 ) static NeoML::CLayerClassRegistrar< classType > __merge__1( _RegisterLayer, __LINE__ )( name1, name2 );
 
 typedef CPtr<CBaseLayer> ( *TCreateLayerFunction )( IMathEngine& mathEngine );
 
 void NEOML_API RegisterLayerName( const char* mainName, const char* additionalName, const std::type_info& typeInfo, TCreateLayerFunction function );
+
+namespace NeoML {
 
 void NEOML_API UnregisterLayerName( const std::type_info& typeInfo );
 

--- a/NeoML/include/NeoML/Dnn/Dnn.h
+++ b/NeoML/include/NeoML/Dnn/Dnn.h
@@ -33,11 +33,11 @@ limitations under the License.
 #define REGISTER_NEOML_LAYER( classType, name ) static NeoML::CLayerClassRegistrar< classType > __merge__1( _RegisterLayer, __LINE__ )( name, 0 );
 #define REGISTER_NEOML_LAYER_EX( classType, name1, name2 ) static NeoML::CLayerClassRegistrar< classType > __merge__1( _RegisterLayer, __LINE__ )( name1, name2 );
 
+namespace NeoML {
+
 typedef CPtr<CBaseLayer> ( *TCreateLayerFunction )( IMathEngine& mathEngine );
 
 void NEOML_API RegisterLayerName( const char* mainName, const char* additionalName, const std::type_info& typeInfo, TCreateLayerFunction function );
-
-namespace NeoML {
 
 void NEOML_API UnregisterLayerName( const std::type_info& typeInfo );
 


### PR DESCRIPTION
Now `NEOML_DNN_LAYER`, `REGISTER_NEOML_LAYER` and `REGISTER_NEOML_LAYER_EX` may be used outside of `namespace NeoML`.

P.S. also moved macros themselves from `namespace NeoML`  for cosmetic purposes

Signed-off-by: Valeriy Fedyunin <valery.fedyunin@abbyy.com>