### PR TITLE
Set CUDA_STANDARD to [C++]11.

### DIFF
--- a/NeoMathEngine/src/CMakeLists.txt
+++ b/NeoMathEngine/src/CMakeLists.txt
@@ -69,6 +69,7 @@ target_sources(${PROJECT_NAME}
 add_library(NeoML::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
+set_target_properties( ${PROJECT_NAME} PROPERTIES CUDA_STANDARD 11 )
 
 source_group("Header Files\\NeoMathEngine" REGULAR_EXPRESSION "^.*NeoMathEngine/.+\.h|inl$")
 source_group("CPU" REGULAR_EXPRESSION "CPU\/.*")


### PR DESCRIPTION
Nvcc -std=c++14 option is incompatible with STL from MSVC 14.29.30037 (aka 16.10).
See https://developercommunity.visualstudio.com/t/VS-16100-isnt-compatible-with-CUDA-11/1433342.
Nvcc complains about 'if constexpr' which is C++17 feature.

Setting CUDA_STANDARD to 17 and (surprisingly) to 11 solves the problem.

|CUDA_STANDARD value|Nvcc command line|
|-|-|
|(none)|-std=c++14|
|11|(none)|
|14|-std=c++14|
|17|-std=c++17|

Signed-off-by: slon872 <30573417+slon872@users.noreply.github.com>