### PR TITLE
Fix CUDA compilation flags (-gencode)

### DIFF
--- a/NeoMathEngine/src/CMakeLists.txt
+++ b/NeoMathEngine/src/CMakeLists.txt
@@ -188,9 +188,9 @@ if((WIN32 OR LINUX) AND CMAKE_SIZEOF_VOID_P EQUAL 8)
             target_compile_definitions(${PROJECT_NAME} PRIVATE NEOML_USE_CUDA)
             target_compile_options(${PROJECT_NAME} PRIVATE
                 $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_35,code=compute_35>
+                $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_61,code=sm_61>
                 $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_75,code=sm_75>
-                $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_86,code=sm_86>
-                $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_86,code=compute_86>)
+                $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_86,code=sm_86>)
             target_sources(${PROJECT_NAME}
                 PRIVATE
                     GPU/CUDA/CublasDll.cpp

--- a/NeoMathEngine/src/CMakeLists.txt
+++ b/NeoMathEngine/src/CMakeLists.txt
@@ -187,9 +187,10 @@ if((WIN32 OR LINUX) AND CMAKE_SIZEOF_VOID_P EQUAL 8)
         else()
             target_compile_definitions(${PROJECT_NAME} PRIVATE NEOML_USE_CUDA)
             target_compile_options(${PROJECT_NAME} PRIVATE
-                $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_35,code=sm_35>
-                $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_50,code=sm_50>
-                $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_86,code=sm_86>)
+                $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_35,code=compute_35>
+                $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_75,code=sm_75>
+                $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_86,code=sm_86>
+                $<$<COMPILE_LANGUAGE:CUDA>:-gencode=arch=compute_86,code=compute_86>)
             target_sources(${PROJECT_NAME}
                 PRIVATE
                     GPU/CUDA/CublasDll.cpp


### PR DESCRIPTION
* `-gencode=arch=compute_35,code=compute_35` adds JIT support for all the GPUs, not mentioned below (GTX 7* 9* generations)
* `-gencode=arch=compute_61,code=sm_61` adds explicit (non-JIT) support of GTX 10* (except Tesla P100)
* `-gencode=arch=compute_75,code=sm_75` adds explicit support of GTX 20* (except TITAN V and NVIDIA V100 server GPU)
* `-gencode=arch=compute_86,code=sm_86` adds explicit support of GTX 30* (except NVIDIA A30 and A100 server GPUs)


Signed-off-by: Valeriy Fedyunin <valery.fedyunin@abbyy.com>