### PR TITLE
Parallel build in NeoMLNoTest.bld.

### DIFF
--- a/Build/NeoMLNoTest.bld
+++ b/Build/NeoMLNoTest.bld
@@ -2,37 +2,35 @@
 
 set;NeoML_BUILD_DIR;%ROOT%\_cmake_working_dir\NeoML
 
-configuration;x86
-	cmd;generate_sln.cmd;Win32 -notest
-end_configuration
-
-configuration;x64
-	cmd;generate_sln.cmd;x64 -notest
-end_configuration
-
-group;para;Debug
+group;para
 	configuration;x86
-		runx;cmake;--build %NeoML_BUILD_DIR%\Win32 --config Debug --target install
+		group;seq
+			cmd;generate_sln.cmd;Win32 -notest -dir "%NeoML_BUILD_DIR%\Win32\Debug"
+			runx;cmake;--build "%NeoML_BUILD_DIR%\Win32\Debug" --config Debug --target install
+		end_group
+		group;seq
+			cmd;generate_sln.cmd;Win32 -notest -dir "%NeoML_BUILD_DIR%\Win32\RelWithDebInfo"
+			runx;cmake;--build "%NeoML_BUILD_DIR%\Win32\RelWithDebInfo" --config RelWithDebInfo --target install
+		end_group
+		group;seq
+			cmd;generate_sln.cmd;Win32 -notest -dir "%NeoML_BUILD_DIR%\Win32\Release"
+			runx;cmake;--build "%NeoML_BUILD_DIR%\Win32\Release" --config Release --target install
+		end_group
 	end_configuration
+
 	configuration;x64
-		runx;cmake;--build %NeoML_BUILD_DIR%\x64 --config Debug --target install
+		group;seq
+			cmd;generate_sln.cmd;x64 -notest -dir "%NeoML_BUILD_DIR%\x64\Debug"
+			runx;cmake;--build "%NeoML_BUILD_DIR%\x64\Debug" --config Debug --target install
+		end_group
+		group;seq
+			cmd;generate_sln.cmd;x64 -notest -dir "%NeoML_BUILD_DIR%\x64\RelWithDebInfo"
+			runx;cmake;--build "%NeoML_BUILD_DIR%\x64\RelWithDebInfo" --config RelWithDebInfo --target install
+		end_group
+		group;seq
+			cmd;generate_sln.cmd;x64 -notest -dir "%NeoML_BUILD_DIR%\x64\Release"
+			runx;cmake;--build "%NeoML_BUILD_DIR%\x64\Release" --config Release --target install
+		end_group
 	end_configuration
 end_group
 
-group;para;RelWithDebInfo
-	configuration;x86
-		runx;cmake;--build %NeoML_BUILD_DIR%\Win32 --config RelWithDebInfo --target install
-	end_configuration
-	configuration;x64
-		runx;cmake;--build %NeoML_BUILD_DIR%\x64 --config RelWithDebInfo --target install
-	end_configuration
-end_group
-
-group;para;Release
-	configuration;x86
-		runx;cmake;--build %NeoML_BUILD_DIR%\Win32 --config Release --target install
-	end_configuration
-	configuration;x64
-		runx;cmake;--build %NeoML_BUILD_DIR%\x64 --config Release --target install
-	end_configuration
-end_group

--- a/Build/generate_sln.cmd
+++ b/Build/generate_sln.cmd
@@ -3,11 +3,23 @@ setlocal EnableDelayedExpansion
 
 set ARCH=x64
 set ENABLE_TEST=ON
+set DIR=
 
 :parseArgs
 
 if "%~1" == "-notest" (
 	set ENABLE_TEST=OFF
+	shift /1
+	goto parseArgs
+)
+
+if "%~1" == "-dir" (
+	if "%~2" == "" (
+		echo Path must follow the -dir.
+		exit /b 1
+	)
+	set "DIR=%~f2"
+	shift /1
 	shift /1
 	goto parseArgs
 )
@@ -29,8 +41,11 @@ if not "%~1" == "" (
 	exit /b 1
 )
 
-if not defined NeoML_BUILD_DIR (
-    set "NeoML_BUILD_DIR=%ROOT%\_cmake_working_dir\NeoML"
+if not defined DIR (
+	if not defined NeoML_BUILD_DIR (
+		set "NeoML_BUILD_DIR=%ROOT%\_cmake_working_dir\NeoML"
+	)
+	set "DIR=%NeoML_BUILD_DIR%\%ARCH%" (
 )
 
 if not defined CMAKE_GENERATOR (
@@ -48,17 +63,18 @@ if not defined CMAKE_SYSTEM_VERSION (
 	set "CMAKE_SYSTEM_VERSION=10"
 )
 
-if exist "%NeoML_BUILD_DIR%\%ARCH%" (
-    rmdir /S /Q "%NeoML_BUILD_DIR%\%ARCH%"
+if exist "%DIR%" (
+    rmdir /S /Q "%DIR%"
 )
-mkdir "%NeoML_BUILD_DIR%\%ARCH%" || exit /b !ERRORLEVEL!
+mkdir "%DIR%" || exit /b !ERRORLEVEL!
 
 echo Generating project:
 echo   Architecture = "%ARCH%"
 echo   Tests = "%ENABLE_TEST%"
+echo   Directory = "%DIR%"
 echo   Generator = "%CMAKE_GENERATOR%"
 echo   Toolset = "%CMAKE_GENERATOR_TOOLSET%"
 echo   Target version = "%CMAKE_SYSTEM_VERSION%"
 echo.
 
-cmake -A %ARCH% -DUSE_FINE_OBJECTS=ON -DNeoML_BUILD_TESTS=%ENABLE_TEST% -DNeoMathEngine_BUILD_TESTS=%ENABLE_TEST% -DCMAKE_SYSTEM_VERSION="%CMAKE_SYSTEM_VERSION%" -B "%NeoML_BUILD_DIR%/%ARCH%" "%ROOT%/NeoML/NeoML" || exit /b !ERRORLEVEL!
+cmake -A %ARCH% -DUSE_FINE_OBJECTS=ON -DNeoML_BUILD_TESTS=%ENABLE_TEST% -DNeoMathEngine_BUILD_TESTS=%ENABLE_TEST% -DCMAKE_SYSTEM_VERSION="%CMAKE_SYSTEM_VERSION%" -B "%DIR%" "%ROOT%/NeoML/NeoML" || exit /b !ERRORLEVEL!

--- a/NeoMathEngine/src/CMakeLists.txt
+++ b/NeoMathEngine/src/CMakeLists.txt
@@ -316,6 +316,7 @@ if(NeoMathEngine_ENABLE_VULKAN)
             target_include_directories(${PROJECT_NAME}
                 PRIVATE 
                     GPU/Vulkan
+                    "${CMAKE_CURRENT_BINARY_DIR}/GPU/Vulkan"
                     ${Vulkan_INCLUDE_DIR}
             )
             

--- a/NeoMathEngine/src/GPU/Vulkan/shaders/CMakeLists.txt
+++ b/NeoMathEngine/src/GPU/Vulkan/shaders/CMakeLists.txt
@@ -165,7 +165,7 @@ set(IB_SHADER_SOURCES
 
 # Directories for common files and result files
 set(COMMON_DIR "${CMAKE_CURRENT_SOURCE_DIR}/common")
-set(RESULTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/generated")
+set(RESULTS_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
 file(MAKE_DIRECTORY ${RESULTS_DIR})
 
@@ -199,11 +199,11 @@ macro(register_shader SHADER IS_IB)
         set(GLSL_DEFINES ${GLSL_DEFINES})
         set(RESULT_FILE ${RESULTS_DIR}/${COMPILED_SHADER})
         set(VAR_NAME "Shader_${SHADER_NAME}")
-        set(FULL_SOURCE_FILE "${SHADER_NAME}_source.tmp")
+        set(FULL_SOURCE_FILE "${RESULTS_DIR}/${SHADER_NAME}_source.tmp")
     else()
         set(RESULT_FILE ${RESULTS_DIR}/${COMPILED_SHADER})
         set(VAR_NAME "Shader_${SHADER_NAME}")
-        set(FULL_SOURCE_FILE "${SHADER_NAME}_source.tmp")
+        set(FULL_SOURCE_FILE "${RESULTS_DIR}/${SHADER_NAME}_source.tmp")
     endif()
 
     if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Windows")


### PR DESCRIPTION
* Vulkan generated code moved to binary dir.
* Separate VS projects are generated for different build configurations.

Before: `Total time: 13.62 minutes, avg. parallelism: 1.496.`
After:  `Total time: 6.50 minutes, avg. parallelism: 4.721.`