### PR TITLE
Allow passing const data to clustering functions

### DIFF
--- a/NeoML/docs/en/API/Clustering/FirstCome.md
+++ b/NeoML/docs/en/API/Clustering/FirstCome.md
@@ -28,7 +28,7 @@ The clustering parameters are described by the  `CFirstComeClustering::CParam` s
 This sample shows how to use the first come clustering algorithm to clusterize the [Iris Data Set](http://archive.ics.uci.edu/ml/datasets/Iris):
 
 ```c++
-void Clusterize( IClusteringData& irisDataSet, CClusteringResult& result )
+void Clusterize( const IClusteringData& irisDataSet, CClusteringResult& result )
 {
 	CFirstComeClustering::CParam params;
 	params.Threshold = 5;

--- a/NeoML/docs/en/API/Clustering/Hierarchical.md
+++ b/NeoML/docs/en/API/Clustering/Hierarchical.md
@@ -27,7 +27,7 @@ The clustering parameters are described by the `CHierarchicalClustering::CParam`
 In this sample an input data set is split into two clusters:
 
 ```c++
-void Clusterize( IClusteringData& data, CClusteringResult& result )
+void Clusterize( const IClusteringData& data, CClusteringResult& result )
 {
 	CHierarchicalClustering::CParam params;
 	params.DistanceType = DF_Euclid;

--- a/NeoML/docs/en/API/Clustering/ISODATA.md
+++ b/NeoML/docs/en/API/Clustering/ISODATA.md
@@ -31,7 +31,7 @@ The clustering parameters are described by the `CIsoDataClustering::CParam` stru
 This sample shows how to use the ISODATA algorithm to clusterize the [Iris Data Set](http://archive.ics.uci.edu/ml/datasets/Iris):
 
 ```c++
-void Clusterize( IClusteringData& irisDataSet, CClusteringResult& result )
+void Clusterize( const IClusteringData& irisDataSet, CClusteringResult& result )
 {
 	CIsoDataClustering::CParam params;
 	params.InitialClustersCount = 1;

--- a/NeoML/docs/en/API/Clustering/README.md
+++ b/NeoML/docs/en/API/Clustering/README.md
@@ -69,7 +69,7 @@ public:
 
 	// Clusterizes the input data 
 	// and returns true if successful with the given parameters
-	virtual bool Clusterize( IClusteringData* data, CClusteringResult& result ) = 0;
+	virtual bool Clusterize( const IClusteringData* data, CClusteringResult& result ) = 0;
 };
 ```
 

--- a/NeoML/docs/en/API/Clustering/kMeans.md
+++ b/NeoML/docs/en/API/Clustering/kMeans.md
@@ -35,7 +35,7 @@ The clustering parameters are described by the `CKMeansClustering::CParam` struc
 This sample shows how to use the k-means algorithm to clusterize the [Iris Data Set](http://archive.ics.uci.edu/ml/datasets/Iris):
 
 ```c++
-void Clusterize( IClusteringData& irisDataSet, CClusteringResult& result )
+void Clusterize( const IClusteringData& irisDataSet, CClusteringResult& result )
 {
 	CKMeansClustering::CParam params;
 	params.Algorithm = CKMeansClustering::KMA_Lloyd;

--- a/NeoML/docs/ru/API/Clustering/FirstCome.md
+++ b/NeoML/docs/ru/API/Clustering/FirstCome.md
@@ -28,7 +28,7 @@
 В данном примере алгоритм по первому пришедшему используется для кластеризации набора данных [Iris Data Set](http://archive.ics.uci.edu/ml/datasets/Iris):
 
 ```c++
-void Clusterize( IClusteringData& irisDataSet, CClusteringResult& result )
+void Clusterize( const IClusteringData& irisDataSet, CClusteringResult& result )
 {
 	CFirstComeClustering::CParam params;
 	params.Threshold = 5;

--- a/NeoML/docs/ru/API/Clustering/Hierarchical.md
+++ b/NeoML/docs/ru/API/Clustering/Hierarchical.md
@@ -27,7 +27,7 @@
 В данном примере набор данных разбивается на два кластера:
 
 ```c++
-void Clusterize( IClusteringData& data, CClusteringResult& result )
+void Clusterize( const IClusteringData& data, CClusteringResult& result )
 {
 	CHierarchicalClustering::CParam params;
 	params.DistanceType = DF_Euclid;

--- a/NeoML/docs/ru/API/Clustering/ISODATA.md
+++ b/NeoML/docs/ru/API/Clustering/ISODATA.md
@@ -31,7 +31,7 @@
 В данном примере алгоритм ISODATA используется для кластеризации набора данных [Iris Data Set](http://archive.ics.uci.edu/ml/datasets/Iris):
 
 ```c++
-void Clusterize( IClusteringData& irisDataSet, CClusteringResult& result )
+void Clusterize( const IClusteringData& irisDataSet, CClusteringResult& result )
 {
 	CIsoDataClustering::CParam params;
 	params.InitialClustersCount = 1;

--- a/NeoML/docs/ru/API/Clustering/README.md
+++ b/NeoML/docs/ru/API/Clustering/README.md
@@ -69,7 +69,7 @@ public:
 
 	// Выполнить разбиение выборки на кластеры.
 	// Возвращает true, если удалось успешно разбить данные на кластеры с заданными параметрами.
-	virtual bool Clusterize( IClusteringData* data, CClusteringResult& result ) = 0;
+	virtual bool Clusterize( const IClusteringData* data, CClusteringResult& result ) = 0;
 };
 ```
 

--- a/NeoML/docs/ru/API/Clustering/kMeans.md
+++ b/NeoML/docs/ru/API/Clustering/kMeans.md
@@ -36,7 +36,7 @@
 В данном примере алгоритм k-средних используется для кластеризации набора данных [Iris Data Set](http://archive.ics.uci.edu/ml/datasets/Iris):
 
 ```c++
-void Clusterize( IClusteringData& irisDataSet, CClusteringResult& result )
+void Clusterize( const IClusteringData& irisDataSet, CClusteringResult& result )
 {
 	CKMeansClustering::CParam params;
 	params.Algorithm = CKMeansClustering::KMA_Lloyd;

--- a/NeoML/include/NeoML/TraditionalML/Clustering.h
+++ b/NeoML/include/NeoML/TraditionalML/Clustering.h
@@ -67,7 +67,7 @@ public:
 
 	// Clusterizes the input data 
 	// and returns true if successful with the given parameters
-	virtual bool Clusterize( IClusteringData*, CClusteringResult& ) = 0;
+	virtual bool Clusterize( const IClusteringData*, CClusteringResult& ) = 0;
 };
 
 } // namespace NeoML

--- a/NeoML/include/NeoML/TraditionalML/FirstComeClustering.h
+++ b/NeoML/include/NeoML/TraditionalML/FirstComeClustering.h
@@ -57,7 +57,7 @@ public:
 	// By default logging is off (set to null to turn off)
 	void SetLog( CTextStream* newLog ) { log = newLog; }
 
-	bool Clusterize( IClusteringData* input, CClusteringResult& result ) override;
+	bool Clusterize( const IClusteringData* input, CClusteringResult& result ) override;
 
 private:
 	const CParam init; // the clustering parameters

--- a/NeoML/include/NeoML/TraditionalML/HierarchicalClustering.h
+++ b/NeoML/include/NeoML/TraditionalML/HierarchicalClustering.h
@@ -60,7 +60,7 @@ public:
 	// IClustering interface methods:
 	// Returns true if the specified distance between the clusters was reached AND
 	// there are more than MinClustersCount clusters
-	bool Clusterize( IClusteringData* input, CClusteringResult& result ) override;
+	bool Clusterize( const IClusteringData* input, CClusteringResult& result ) override;
 
 	// Information about one step of the clustering
 	struct CMergeInfo {
@@ -85,7 +85,7 @@ public:
 	// - InitialClusters means dendrogram[0]
 	// - InitialClusters+1 means dendrogram[1]
 	// - etc. till InitialClusters+DendrogramSize-1
-	bool ClusterizeEx( IClusteringData* input, CClusteringResult& result,
+	bool ClusterizeEx( const IClusteringData* input, CClusteringResult& result,
 		CArray<CMergeInfo>& dendrogram, CArray<int>& dendrogramIndices );
 
 private:
@@ -93,7 +93,7 @@ private:
 	CTextStream* log; // the logging stream
 	CArray<CClusterCenter> initialClusters; // the initial cluster centers
 
-	bool clusterizeImpl( IClusteringData* input, CClusteringResult& result,
+	bool clusterizeImpl( const IClusteringData* input, CClusteringResult& result,
 		CArray<CMergeInfo>* dendrogram, CArray<int>* dendrogramIndices ) const;
 	bool naiveAlgo( const CFloatMatrixDesc& matrix, const CArray<double>& weights,
 		CClusteringResult& result, CArray<CMergeInfo>* dendrogram, CArray<int>* dendrogramIndices ) const;

--- a/NeoML/include/NeoML/TraditionalML/IsoDataClustering.h
+++ b/NeoML/include/NeoML/TraditionalML/IsoDataClustering.h
@@ -60,7 +60,7 @@ public:
 	// IClustering inteface methods:
 	// Clusterizes the input data and returns true if successful,
 	// false if more iterations are needed
-	bool Clusterize( IClusteringData* input, CClusteringResult& result ) override;
+	bool Clusterize( const IClusteringData* input, CClusteringResult& result ) override;
 
 private:
 	// A pair of clusters that will be merged

--- a/NeoML/include/NeoML/TraditionalML/KMeansClustering.h
+++ b/NeoML/include/NeoML/TraditionalML/KMeansClustering.h
@@ -97,7 +97,7 @@ public:
 	// IClustering inteface methods:
 	// Clusterizes the input data and returns true if successful,
 	// false if more iterations are needed
-	bool Clusterize( IClusteringData* data, CClusteringResult& result ) override;
+	bool Clusterize( const IClusteringData* data, CClusteringResult& result ) override;
 
 private:
 	IThreadPool* const threadPool; // parallelize execution
@@ -108,7 +108,7 @@ private:
 	CArray<CClusterCenter> initialClusterCenters{}; // the initial cluster centers
 
 	// Single run of clusterization with given seed
-	bool runClusterization( IClusteringData* input, int seed, CClusteringResult& result, double& inertia );
+	bool runClusterization( const IClusteringData* input, int seed, CClusteringResult& result, double& inertia );
 
 	// Initial cluster selection for sparse data
 	void selectInitialClusters( const CFloatMatrixDesc& matrix, int seed );
@@ -127,7 +127,7 @@ private:
 	void updateMoveDistance( const CArray<CClusterCenter>& oldCenters, CArray<float>& moveDistance ) const;
 
 	// Specific case for dense data with Euclidean metrics and Lloyd algorithm
-	bool denseLloydL2Clusterize( IClusteringData* rawData, int seed, CClusteringResult& result, double& inertia );
+	bool denseLloydL2Clusterize( const IClusteringData* rawData, int seed, CClusteringResult& result, double& inertia );
 	// Initial cluster selection
 	void selectInitialClusters( const CDnnBlob& data, int seed, CDnnBlob& centers );
 	void defaultInitialization( const CDnnBlob& data, int seed, CDnnBlob& centers );

--- a/NeoML/src/TraditionalML/FirstComeClustering.cpp
+++ b/NeoML/src/TraditionalML/FirstComeClustering.cpp
@@ -29,7 +29,7 @@ CFirstComeClustering::CFirstComeClustering( const CParam& params ) :
 	NeoAssert( 0 < init.MinClusterSizeRatio && init.MinClusterSizeRatio <= 1 );
 }
 
-bool CFirstComeClustering::Clusterize( IClusteringData* input, CClusteringResult& result )
+bool CFirstComeClustering::Clusterize( const IClusteringData* input, CClusteringResult& result )
 {
 	result.ClusterCount = 0;
 	result.Data.SetSize( input->GetVectorCount() );

--- a/NeoML/src/TraditionalML/HierarchicalClustering.cpp
+++ b/NeoML/src/TraditionalML/HierarchicalClustering.cpp
@@ -41,18 +41,18 @@ CHierarchicalClustering::CHierarchicalClustering( const CParam& _params ) :
 	NeoAssert( params.MinClustersCount > 0 );
 }
 
-bool CHierarchicalClustering::Clusterize( IClusteringData* input, CClusteringResult& result )
+bool CHierarchicalClustering::Clusterize( const IClusteringData* input, CClusteringResult& result )
 {
 	return clusterizeImpl( input, result, nullptr, nullptr );
 }
 
-bool CHierarchicalClustering::ClusterizeEx( IClusteringData* input, CClusteringResult& result,
+bool CHierarchicalClustering::ClusterizeEx( const IClusteringData* input, CClusteringResult& result,
 	CArray<CMergeInfo>& dendrogram, CArray<int>& dendrogramIndices )
 {
 	return clusterizeImpl( input, result, &dendrogram, &dendrogramIndices );
 }
 
-bool CHierarchicalClustering::clusterizeImpl( IClusteringData* data, CClusteringResult& result,
+bool CHierarchicalClustering::clusterizeImpl( const IClusteringData* data, CClusteringResult& result,
 	CArray<CMergeInfo>* dendrogram, CArray<int>* dendrogramIndices ) const
 {
 	NeoAssert( params.Linkage != L_Ward || params.DistanceType == DF_Euclid ); // Ward works only in L2

--- a/NeoML/src/TraditionalML/IsoDataClustering.cpp
+++ b/NeoML/src/TraditionalML/IsoDataClustering.cpp
@@ -39,7 +39,7 @@ CIsoDataClustering::CIsoDataClustering( const CParam& _params ) :
 
 CIsoDataClustering::~CIsoDataClustering() = default;
 
-bool CIsoDataClustering::Clusterize( IClusteringData* input, CClusteringResult& result )
+bool CIsoDataClustering::Clusterize( const IClusteringData* input, CClusteringResult& result )
 {
 	NeoAssert( params.MaxIterations > 0 );
 	NeoAssert( params.InitialClustersCount > 0 );

--- a/NeoML/src/TraditionalML/KMeansClustering.cpp
+++ b/NeoML/src/TraditionalML/KMeansClustering.cpp
@@ -773,7 +773,7 @@ CKMeansClustering::~CKMeansClustering()
 	delete threadPool;
 }
 
-bool CKMeansClustering::Clusterize( IClusteringData* input, CClusteringResult& result )
+bool CKMeansClustering::Clusterize( const IClusteringData* input, CClusteringResult& result )
 {
 	double inertia;
 	// Run first clusterization with params.Seed as initial seed
@@ -799,7 +799,7 @@ bool CKMeansClustering::Clusterize( IClusteringData* input, CClusteringResult& r
 	return succeeded;
 }
 
-bool CKMeansClustering::runClusterization( IClusteringData* input, int seed, CClusteringResult& result, double& inertia )
+bool CKMeansClustering::runClusterization( const IClusteringData* input, int seed, CClusteringResult& result, double& inertia )
 {
 	NeoAssert( input != 0 );
 
@@ -856,7 +856,7 @@ bool CKMeansClustering::runClusterization( IClusteringData* input, int seed, CCl
 	return success;
 }
 
-bool CKMeansClustering::denseLloydL2Clusterize( IClusteringData* rawData, int seed, CClusteringResult& result, double& inertia )
+bool CKMeansClustering::denseLloydL2Clusterize( const IClusteringData* rawData, int seed, CClusteringResult& result, double& inertia )
 {
 	NeoAssert( params.DistanceFunc == DF_Euclid );
 	NeoAssert( params.Algo == KMA_Lloyd );

--- a/NeoML/test/src/ClusteringTest.cpp
+++ b/NeoML/test/src/ClusteringTest.cpp
@@ -25,7 +25,7 @@ namespace NeoMLTest {
 
 //---------------------------------------------------------------------------------------------------------------------
 
-typedef void ( *TClusteringFunction )( IClusteringData* data, CClusteringResult& result );
+typedef void ( *TClusteringFunction )( const IClusteringData* data, CClusteringResult& result );
 
 struct CClusteringTestParams {
 	TClusteringFunction Clusterize{};
@@ -39,7 +39,7 @@ struct CClusteringTest : public CNeoMLTestFixture, public ::testing::WithParamIn
 
 //---------------------------------------------------------------------------------------------------------------------
 
-typedef void ( *THierarchicalDendrogram )( IClusteringData* data, CClusteringResult& result,
+typedef void ( *THierarchicalDendrogram )( const IClusteringData* data, CClusteringResult& result,
 	CArray<CHierarchicalClustering::CMergeInfo>& dendrogram, CArray<int>& dendrogramIndices );
 
 struct CClusteringDendrogramTestParams {
@@ -172,7 +172,7 @@ static void generateData( int vectorCount, int featureCount, int seed,
 
 // Clustering functions
 
-static void firstComeClustering( IClusteringData* data, CClusteringResult& result )
+static void firstComeClustering( const IClusteringData* data, CClusteringResult& result )
 {
 	CFirstComeClustering::CParam params;
 	params.Threshold = 5.0;
@@ -182,7 +182,7 @@ static void firstComeClustering( IClusteringData* data, CClusteringResult& resul
 }
 
 template<CHierarchicalClustering::TLinkage LINKAGE>
-static void hierarchicalClustering( IClusteringData* data, CClusteringResult& result )
+static void hierarchicalClustering( const IClusteringData* data, CClusteringResult& result )
 {
 	CHierarchicalClustering::CParam params;
 	params.Linkage = LINKAGE;
@@ -200,7 +200,7 @@ static void hierarchicalClustering( IClusteringData* data, CClusteringResult& re
 	}
 }
 
-static void isoDataClustering( IClusteringData* data, CClusteringResult& result )
+static void isoDataClustering( const IClusteringData* data, CClusteringResult& result )
 {
 	CIsoDataClustering::CParam params;
 	params.MinClusterSize = 1;
@@ -215,7 +215,7 @@ static void isoDataClustering( IClusteringData* data, CClusteringResult& result 
 	isoData.Clusterize( data, result );
 }
 
-static void kmeansLloydClustering( IClusteringData* data, CClusteringResult& result )
+static void kmeansLloydClustering( const IClusteringData* data, CClusteringResult& result )
 {
 	CKMeansClustering::CParam params;
 	params.DistanceFunc = DF_Euclid;
@@ -229,7 +229,7 @@ static void kmeansLloydClustering( IClusteringData* data, CClusteringResult& res
 	kMeans.Clusterize( data, result );
 }
 
-static void kmeansElkanClustering( IClusteringData* data, CClusteringResult& result )
+static void kmeansElkanClustering( const IClusteringData* data, CClusteringResult& result )
 {
 	CKMeansClustering::CParam params;
 	params.DistanceFunc = DF_Euclid;
@@ -331,7 +331,7 @@ static void precalcTestImpl( TClusteringFunction clusterize, const CClusteringRe
 	EXPECT_TRUE( isEqual( denseResult, expectedResult ) );
 }
 
-static void kmeansElkanDefaultInitClustering( IClusteringData* data, CClusteringResult& result )
+static void kmeansElkanDefaultInitClustering( const IClusteringData* data, CClusteringResult& result )
 {
 	CKMeansClustering::CParam params;
 	params.DistanceFunc = DF_Euclid;

--- a/NeoML/test/src/ClusteringTest.cpp
+++ b/NeoML/test/src/ClusteringTest.cpp
@@ -406,7 +406,7 @@ static void getDendrogramData( CPtr<IClusteringData>& denseData, CArray<CHierarc
 }
 
 template<CHierarchicalClustering::TLinkage LINKAGE>
-static void hierarchicalDendrogram( IClusteringData* data, CClusteringResult& result,
+static void hierarchicalDendrogram( const IClusteringData* data, CClusteringResult& result,
 	CArray<CHierarchicalClustering::CMergeInfo>& dendrogram, CArray<int>& dendrogramIndices )
 {
 	CHierarchicalClustering::CParam params;
@@ -419,7 +419,7 @@ static void hierarchicalDendrogram( IClusteringData* data, CClusteringResult& re
 	EXPECT_TRUE( clustering.ClusterizeEx( data, result, dendrogram, dendrogramIndices ) );
 }
 
-typedef void ( *THierarchicalClusteringFunction )( IClusteringData* data, CClusteringResult& result,
+typedef void ( *THierarchicalClusteringFunction )( const IClusteringData* data, CClusteringResult& result,
 	CArray<CHierarchicalClustering::CMergeInfo>& dendrogram, CArray<int>& dendrogramIndices );
 
 static inline bool compareVectors( const CFloatVector& first, const CFloatVector& second, float eps = 1e-5f )


### PR DESCRIPTION
Clustering functions currently accept data by a non-const pointer. None of them actually modify the data. I'm not aware of any clustering algorithms that modify the feature vectors, so I believe the interface should allow passing const data. This PR implements that.