### PR TITLE
support CMAKE_UNITY_BUILD

### DIFF
--- a/NeoML/CMakeLists.txt
+++ b/NeoML/CMakeLists.txt
@@ -33,6 +33,15 @@ option(NeoML_BUILD_TESTS "Enable and build all of NeoML's tests." ON)
 # Build NeoML as shared library.
 option(NeoML_BUILD_SHARED "Build NeoML as shared library." ON)
 
+# Use CMAKE_UNITY_BUILD or not
+option(NeoML_UNITY_BUILD "Use Unity (Jumbo) build cmake's feature" ON)
+if(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
+    set(CMAKE_UNITY_BUILD ${NeoML_UNITY_BUILD})
+endif()
+
+# Set UNITY_BUILD_BATCH_SIZE. This option is ignored if not CMAKE_UNITY_BUILD
+set(NeoML_UNITY_BUILD_BATCH_SIZE 8 CACHE STRING "Batch size for Unity build" )
+
 # Install NeoML or not
 option(NeoML_INSTALL "Install NeoML" ON)
 

--- a/NeoML/src/CMakeLists.txt
+++ b/NeoML/src/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 add_library(NeoML::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
-target_sources( ${PROJECT_NAME} PRIVATE
+set(NeoML_SOURCES
     ArchiveFile.cpp
     NeoML.cpp
     Random.cpp
@@ -16,7 +16,6 @@ target_sources( ${PROJECT_NAME} PRIVATE
     Dnn/Dnn.cpp
     Dnn/DnnBlob.cpp
     Dnn/DnnInitializer.cpp
-    Dnn/DnnSolver.cpp
     Dnn/DnnSparseMatrix.cpp
     Dnn/Layers/3dConvLayer.cpp
     Dnn/Layers/3dPoolingLayer.cpp
@@ -62,7 +61,6 @@ target_sources( ${PROJECT_NAME} PRIVATE
     Dnn/Layers/ImageResizeLayer.cpp
     Dnn/Layers/IndRnnLayer.cpp
     Dnn/Layers/IrnnLayer.cpp
-    Dnn/Layers/LossLayer.cpp
     Dnn/Layers/LrnLayer.cpp
     Dnn/Layers/LstmLayer.cpp
     Dnn/Layers/MatrixMultiplicationLayer.cpp
@@ -100,17 +98,10 @@ target_sources( ${PROJECT_NAME} PRIVATE
     TraditionalML/ClassificationProbability.cpp
     TraditionalML/ClusterCenter.cpp
     TraditionalML/CommonCluster.cpp
-    TraditionalML/CompactRegressionTree.cpp
-    TraditionalML/CompactRegressionTree.h
     TraditionalML/CrossValidation.cpp
     TraditionalML/CrossValidationSubProblem.cpp
-    TraditionalML/DecisionTreeClassificationModel.cpp
-    TraditionalML/DecisionTreeClassificationModel.h
     TraditionalML/DecisionTreeNodeBase.cpp
-    TraditionalML/DecisionTreeNodeBase.h
     TraditionalML/DecisionTreeNodeClassificationStatistic.cpp
-    TraditionalML/DecisionTreeNodeClassificationStatistic.h
-    TraditionalML/DecisionTreeNodeStatisticBase.h
     TraditionalML/DecisionTree.cpp
     TraditionalML/DifferentialEvolution.cpp
     TraditionalML/FeatureSelection.cpp
@@ -118,59 +109,83 @@ target_sources( ${PROJECT_NAME} PRIVATE
     TraditionalML/FloatVector.cpp
     TraditionalML/Function.cpp
     TraditionalML/FunctionEvaluation.cpp
-    TraditionalML/GradientBoost.cpp
     TraditionalML/GradientBoostFastHistProblem.cpp
-    TraditionalML/GradientBoostFastHistProblem.h
     TraditionalML/GradientBoostFastHistTreeBuilder.cpp
-    TraditionalML/GradientBoostFastHistTreeBuilder.h
     TraditionalML/GradientBoostFullProblem.cpp
-    TraditionalML/GradientBoostFullProblem.h
     TraditionalML/GradientBoostFullTreeBuilder.cpp
-    TraditionalML/GradientBoostFullTreeBuilder.h
-    TraditionalML/GradientBoostModel.cpp
-    TraditionalML/GradientBoostModel.h
     TraditionalML/GradientBoostQSEnsemble.cpp
-    TraditionalML/GradientBoostQSEnsemble.h
-    TraditionalML/GradientBoostQuickScorer.cpp
-    TraditionalML/GradientBoostStatisticsSingle.h
-    TraditionalML/GradientBoostStatisticsMulti.h
     TraditionalML/HierarchicalClustering.cpp
     TraditionalML/IsoDataClustering.cpp
     TraditionalML/KMeansClustering.cpp
     TraditionalML/Linear.cpp
-    TraditionalML/LinearBinaryModel.cpp
-    TraditionalML/LinearBinaryModel.h
     TraditionalML/LinkedRegressionTree.cpp
-    TraditionalML/LinkedRegressionTree.h
     TraditionalML/MemoryProblem.cpp
-    TraditionalML/NaiveHierarchicalClustering.h
     TraditionalML/NaiveHierarchicalClustering.cpp
-    TraditionalML/NnChainHierarchicalClustering.h
     TraditionalML/NnChainHierarchicalClustering.cpp
     TraditionalML/OneVersusAll.cpp
-    TraditionalML/OneVersusAllModel.cpp
-    TraditionalML/OneVersusAllModel.h
     TraditionalML/OneVersusOne.cpp
-    TraditionalML/OneVersusOneModel.cpp
-    TraditionalML/OneVersusOneModel.h
     TraditionalML/PlattScalling.cpp
     TraditionalML/ProblemWrappers.cpp
-    TraditionalML/ProblemWrappers.h
-    TraditionalML/ProblemWrappers.inl
-    TraditionalML/RegressionTree.h
     TraditionalML/Score.cpp
-    TraditionalML/SerializeCompact.h
     TraditionalML/Shuffler.cpp
     TraditionalML/SMOptimizer.cpp
-    TraditionalML/SMOptimizer.h
     TraditionalML/SparseFloatMatrix.cpp
-    TraditionalML/SparseFloatVector.cpp
     TraditionalML/StratifiedCrossValidationSubProblem.cpp
     TraditionalML/Svm.cpp
-    TraditionalML/SvmBinaryModel.cpp
-    TraditionalML/SvmBinaryModel.h
     TraditionalML/SvmKernel.cpp
     TraditionalML/TrustRegionNewtonOptimizer.cpp
+)
+set(NeoML_NON_UNITY_SOURCES
+    Dnn/DnnSolver.cpp
+    Dnn/Layers/LossLayer.cpp
+    Dnn/Layers/LstmLayer.cpp
+    TraditionalML/CompactRegressionTree.cpp
+    TraditionalML/DecisionTreeClassificationModel.cpp
+    TraditionalML/GradientBoost.cpp
+    TraditionalML/GradientBoostModel.cpp
+    TraditionalML/GradientBoostQuickScorer.cpp
+    TraditionalML/LinearBinaryModel.cpp
+    TraditionalML/LinkedRegressionTree.cpp
+    TraditionalML/OneVersusAllModel.cpp
+    TraditionalML/OneVersusOneModel.cpp
+    TraditionalML/SparseFloatVector.cpp
+    TraditionalML/SvmBinaryModel.cpp
+)
+
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+    UNITY_BUILD_MODE BATCH
+    UNITY_BUILD_BATCH_SIZE ${NeoML_UNITY_BUILD_BATCH_SIZE}
+)
+set_property(SOURCE ${NeoML_NON_UNITY_SOURCES} PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
+
+target_sources( ${PROJECT_NAME} PRIVATE
+    ${NeoML_SOURCES}
+    ${NeoML_NON_UNITY_SOURCES}
+    TraditionalML/CompactRegressionTree.h
+    TraditionalML/DecisionTreeClassificationModel.h
+    TraditionalML/DecisionTreeNodeBase.h
+    TraditionalML/DecisionTreeNodeClassificationStatistic.h
+    TraditionalML/DecisionTreeNodeStatisticBase.h
+    TraditionalML/GradientBoostFastHistProblem.h
+    TraditionalML/GradientBoostFastHistTreeBuilder.h
+    TraditionalML/GradientBoostFullProblem.h
+    TraditionalML/GradientBoostFullTreeBuilder.h
+    TraditionalML/GradientBoostModel.h
+    TraditionalML/GradientBoostQSEnsemble.h
+    TraditionalML/GradientBoostStatisticsSingle.h
+    TraditionalML/GradientBoostStatisticsMulti.h
+    TraditionalML/LinearBinaryModel.h
+    TraditionalML/LinkedRegressionTree.h
+    TraditionalML/NaiveHierarchicalClustering.h
+    TraditionalML/NnChainHierarchicalClustering.h
+    TraditionalML/OneVersusAllModel.h
+    TraditionalML/OneVersusOneModel.h
+    TraditionalML/ProblemWrappers.h
+    TraditionalML/RegressionTree.h
+    TraditionalML/SerializeCompact.h
+    TraditionalML/SMOptimizer.h
+    TraditionalML/SvmBinaryModel.h
+    TraditionalML/ProblemWrappers.inl
 
     # Headers
     ../include/NeoML/ArchiveFile.h

--- a/NeoML/test/desktop/CMakeLists.txt
+++ b/NeoML/test/desktop/CMakeLists.txt
@@ -12,6 +12,10 @@ add_executable(${PROJECT_NAME}
     main.cpp
 )
 
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+    UNITY_BUILD_MODE GROUP
+)
+
 configure_target(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE NeoMLTestSrc gtest NeoML)

--- a/NeoML/test/src/CMakeLists.txt
+++ b/NeoML/test/src/CMakeLists.txt
@@ -2,6 +2,10 @@ project(NeoMLTestSrc)
 
 add_library(${PROJECT_NAME} INTERFACE)
 
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+    UNITY_BUILD_MODE GROUP
+)
+
 target_sources(${PROJECT_NAME} INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/AutoDiffTest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/common.h

--- a/NeoMathEngine/src/CMakeLists.txt
+++ b/NeoMathEngine/src/CMakeLists.txt
@@ -7,9 +7,7 @@ else()
     add_library(${PROJECT_NAME} STATIC common.cpp)
 endif()
 
-target_sources(${PROJECT_NAME}
-    PRIVATE
-
+set(CPU_COMMON_SOURCES
     # Sources
     CPU/CpuMathEngineBlas.cpp
     CPU/CpuMathEngineDnn3dConv.cpp
@@ -32,6 +30,11 @@ target_sources(${PROJECT_NAME}
     MathEngineHostStackAllocator.cpp
     MemoryPool.cpp
     common.cpp
+)
+
+target_sources(${PROJECT_NAME}
+    PRIVATE
+    ${CPU_COMMON_SOURCES}
     # Headers
     common.h
     MathEngineAllocator.h
@@ -71,6 +74,12 @@ target_sources(${PROJECT_NAME}
 
 add_library(NeoML::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+    UNITY_BUILD_MODE GROUP
+)
+set_property(SOURCE ${CPU_COMMON_SOURCES} PROPERTY UNITY_GROUP 1)
+set_property(SOURCE MathEngineDeviceStackAllocator.cpp PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
+
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
 
 source_group("Header Files\\NeoMathEngine" REGULAR_EXPRESSION "^.*NeoMathEngine/.+\.h|inl$")
@@ -101,13 +110,16 @@ endif()
 
 # CPU specific settings
 if((DARWIN AND CMAKE_SYSTEM_PROCESSOR MATCHES "^arm64.*") OR (ANDROID AND ANDROID_ABI MATCHES "^arm.*") OR (IOS AND IOS_ARCH MATCHES "^arm.*"))
-    target_sources(${PROJECT_NAME} 
-    PRIVATE
+    set(CPU_ARM_SOURCES
         CPU/arm/CpuArmMathEngineBlas.cpp
         CPU/arm/CpuArmMathEngineDnn.cpp
         CPU/arm/CpuArmMathEngineVectorMath.cpp
         CPU/arm/CpuArmMathEngineDnn3dConv.cpp
         CPU/arm/CpuArmMathEngineMatrixMultiplying.cpp
+    )
+    target_sources(${PROJECT_NAME} 
+    PRIVATE
+        ${CPU_ARM_SOURCES}
         CPU/arm/CpuArm.h
         CPU/arm/CpuArmMathEngineBlasPrivate.h
         CPU/arm/CpuArmMathEngineVectorMathPrivate.h
@@ -122,21 +134,26 @@ if((DARWIN AND CMAKE_SYSTEM_PROCESSOR MATCHES "^arm64.*") OR (ANDROID AND ANDROI
         CPU/arm/MatrixMultiplyingInterleaved/MicroKernels/Kernel_ARM64_8x12.h
         CPU/arm/MatrixMultiplyingInterleaved/MicroKernels/Kernel_ARM64_8x4.h
     )
+    set_property(SOURCE ${CPU_ARM_SOURCES} PROPERTY UNITY_GROUP 1)
     source_group("CPU\\arm" REGULAR_EXPRESSION "CPU\/arm\/.*")
     target_include_directories(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CPU/arm>)
 else()
-    target_sources(${PROJECT_NAME} 
-    PRIVATE
+    set(CPU_X86_SOURCES
         CPU/x86/CpuX86MathEngineBlas.cpp
         CPU/x86/CpuX86MathEngineBlasMkl.cpp
         CPU/x86/CpuX86MathEngineDnn.cpp
         CPU/x86/CpuX86MathEngineVectorMath.cpp
         CPU/x86/CpuX86MathEngineVectorMathMkl.cpp
         CPU/x86/CpuX86MathEngineDnn3dConv.cpp
+    )
+    target_sources(${PROJECT_NAME} 
+    PRIVATE
+        ${CPU_X86_SOURCES}
         CPU/x86/CpuX86.h
         CPU/x86/CpuX86MathEngineBlasPrivate.h
         CPU/x86/CpuX86MathEngineVectorMathPrivate.h
     )
+    set_property(SOURCE ${CPU_X86_SOURCES} PROPERTY UNITY_GROUP 1)
     source_group("CPU\\x86" REGULAR_EXPRESSION "CPU\/x86\/.*")
     target_include_directories(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CPU/x86>)
     if(NEOML_USE_AVX)
@@ -328,28 +345,32 @@ if(NeoMathEngine_ENABLE_VULKAN)
                     ${Vulkan_INCLUDE_DIR}
             )
             
+            set(VULKAN_SOURCES
+                GPU/Vulkan/VulkanCommandQueue.cpp
+                GPU/Vulkan/VulkanDll.cpp
+                GPU/Vulkan/VulkanImage.cpp
+                GPU/Vulkan/VulkanMathEngineBlas.cpp
+                GPU/Vulkan/VulkanMathEngineDnnConvs.cpp
+                GPU/Vulkan/VulkanMathEngineDnn.cpp
+                GPU/Vulkan/VulkanMathEngineDnnPoolings.cpp
+                GPU/Vulkan/VulkanMathEngineDnnLrn.cpp
+                GPU/Vulkan/VulkanMathEngine.cpp
+                GPU/Vulkan/VulkanMathEngineVectorMath.cpp
+                GPU/Vulkan/VulkanShader.cpp
+                GPU/Vulkan/VulkanMemory.cpp
+            )
             target_sources(${PROJECT_NAME}
                 PRIVATE
-                    GPU/Vulkan/VulkanCommandQueue.cpp
+                    ${VULKAN_SOURCES}
                     GPU/Vulkan/VulkanCommandQueue.h
-                    GPU/Vulkan/VulkanDll.cpp
                     GPU/Vulkan/VulkanDll.h
-                    GPU/Vulkan/VulkanImage.cpp
                     GPU/Vulkan/VulkanImage.h
-                    GPU/Vulkan/VulkanMathEngineBlas.cpp
-                    GPU/Vulkan/VulkanMathEngineDnnConvs.cpp
-                    GPU/Vulkan/VulkanMathEngineDnn.cpp
-                    GPU/Vulkan/VulkanMathEngineDnnPoolings.cpp
-                    GPU/Vulkan/VulkanMathEngineDnnLrn.cpp
-                    GPU/Vulkan/VulkanMathEngine.cpp
                     GPU/Vulkan/VulkanMathEngine.h
-                    GPU/Vulkan/VulkanMathEngineVectorMath.cpp
-                    GPU/Vulkan/VulkanShader.cpp
                     GPU/Vulkan/VulkanShader.h
-                    GPU/Vulkan/VulkanMemory.cpp
                     GPU/Vulkan/VulkanMemory.h
                     GPU/Vulkan/shaders/common/CommonStruct.h
             )
+            set_property(SOURCE ${VULKAN_SOURCES} PROPERTY UNITY_GROUP 2)
             source_group("GPU\\Vulkan" REGULAR_EXPRESSION "GPU\/Vulkan\/[A-Za-z0-9_]+\.(h|cpp)")
             
             add_subdirectory(GPU/Vulkan/shaders)

--- a/NeoMathEngine/test/FullTestDesktop/CMakeLists.txt
+++ b/NeoMathEngine/test/FullTestDesktop/CMakeLists.txt
@@ -8,6 +8,10 @@ add_executable(${PROJECT_NAME}
     FullTestDesktop.cpp
 )
 
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+    UNITY_BUILD_MODE GROUP
+)
+
 if(MSVC)
     target_link_options(${PROJECT_NAME} PRIVATE "/SUBSYSTEM:Console")
 endif()

--- a/NeoMathEngine/test/src/common/CMakeLists.txt
+++ b/NeoMathEngine/test/src/common/CMakeLists.txt
@@ -7,6 +7,10 @@ add_library(${PROJECT_NAME}
 	TestParams.h
 )
 
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+    UNITY_BUILD_MODE GROUP
+)
+
 configure_target(${PROJECT_NAME})
 
 if(USE_FINE_OBJECTS AND (IOS OR DARWIN))

--- a/NeoMathEngine/test/src/inference/CMakeLists.txt
+++ b/NeoMathEngine/test/src/inference/CMakeLists.txt
@@ -2,6 +2,10 @@ project(InferenceTests)
 
 add_library(${PROJECT_NAME} INTERFACE)
 
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+    UNITY_BUILD_MODE GROUP
+)
+
 target_sources(${PROJECT_NAME} INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/AddVectorToMatrixColumnsTest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/AddVectorToMatrixRowsTest.cpp

--- a/NeoMathEngine/test/src/inference/CMakeLists.txt
+++ b/NeoMathEngine/test/src/inference/CMakeLists.txt
@@ -2,10 +2,6 @@ project(InferenceTests)
 
 add_library(${PROJECT_NAME} INTERFACE)
 
-set_target_properties( ${PROJECT_NAME} PROPERTIES
-    UNITY_BUILD_MODE GROUP
-)
-
 target_sources(${PROJECT_NAME} INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/AddVectorToMatrixColumnsTest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/AddVectorToMatrixRowsTest.cpp

--- a/NeoMathEngine/test/src/learn/CMakeLists.txt
+++ b/NeoMathEngine/test/src/learn/CMakeLists.txt
@@ -2,10 +2,6 @@ project(LearnTests)
 
 add_library(${PROJECT_NAME} INTERFACE)
 
-set_target_properties( ${PROJECT_NAME} PROPERTIES
-    UNITY_BUILD_MODE GROUP
-)
-
 target_sources(${PROJECT_NAME} INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/AddHeightIndexTest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/AddMatrixElementsToVectorTest.cpp

--- a/NeoMathEngine/test/src/learn/CMakeLists.txt
+++ b/NeoMathEngine/test/src/learn/CMakeLists.txt
@@ -2,6 +2,10 @@ project(LearnTests)
 
 add_library(${PROJECT_NAME} INTERFACE)
 
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+    UNITY_BUILD_MODE GROUP
+)
+
 target_sources(${PROJECT_NAME} INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/AddHeightIndexTest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/AddMatrixElementsToVectorTest.cpp

--- a/NeoOnnx/src/CMakeLists.txt
+++ b/NeoOnnx/src/CMakeLists.txt
@@ -6,6 +6,10 @@ endif()
 
 add_library(NeoML::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+    UNITY_BUILD_MODE GROUP
+)
+
 target_sources( ${PROJECT_NAME} PRIVATE
     GraphInput.cpp
     GraphInitializer.cpp

--- a/Sources.txt
+++ b/Sources.txt
@@ -13,7 +13,7 @@ git;https://tfs/HQ/ThirdParty/_git/MKL
 get;ThirdParty/MKL;/;MKL 2018 Update4 1.0.2.0
 
 git;https://tfs/HQ/Tools_Libs/_git/NeoMLTest
-get;NeoMLTest;/;NeoMLTest-master 1.0.40.0
+get;NeoMLTest;/;NeoMLTest-master 1.0.41.0
 
 copy;%ROOT%/../NeoML;%ROOT%/NeoML/NeoML
 copy;%ROOT%/../NeoMathEngine;%ROOT%/NeoML/NeoMathEngine


### PR DESCRIPTION
This feature significantly speeds up the build (crucial for containers mapped to ntfs).
Set enabled by default.
To disable specify -DNeoML_UNITY_BUILD=OFF in cmake options.

Truly supported in NeoML and NeoMathEngine (except for .mm and .cu sources).
NeoOnnx and tests are being built as usual (done via setting UNITY_BUILD_MODE to GROUP without groups definitions).

Signed-off-by: sansanch5 <a.a.pakhomoff@gmail.com>