### PR TITLE
Fix unused field warning when NEOML_USE_AVX is disabled

### DIFF
--- a/NeoMathEngine/src/CPU/CpuMathEngine.cpp
+++ b/NeoMathEngine/src/CPU/CpuMathEngine.cpp
@@ -71,6 +71,9 @@ CCpuMathEngine::CCpuMathEngine( int _threadCount, size_t _memoryLimit ) :
 			customSgemmFunction = simdMathEngine->GetSgemmFunction();
 		}
 	}
+#else // NEOML_USE_AVX
+	// warning fix
+	(void)customSgemmFunction;
 #endif
 }
 


### PR DESCRIPTION
Signed-off-by: Valeriy Fedyunin <valery.fedyunin@abbyy.com>