### PR TITLE
Also use __ANDROID__ macro for android detection

### DIFF
--- a/NeoML/include/NeoML/Platforms.h
+++ b/NeoML/include/NeoML/Platforms.h
@@ -48,7 +48,7 @@ limitations under the License.
 		#define FINE_32_BIT 1
 	#endif
 	#define FINE_LITTLE_ENDIAN 1
-#elif defined(_ANDROID)
+#elif defined(_ANDROID) || defined(__ANDROID__)
 	#define FINE_PLATFORM( a ) a
 	#define FINE_BIT( a ) a
 	#define FINE_BYTE_ORDER( a ) a

--- a/NeoMathEngine/include/NeoMathEngine/Platforms.h
+++ b/NeoMathEngine/include/NeoMathEngine/Platforms.h
@@ -48,7 +48,7 @@ limitations under the License.
 		#define FINE_32_BIT 1
 	#endif
 	#define FINE_LITTLE_ENDIAN 1
-#elif defined(_ANDROID)
+#elif defined(_ANDROID) || defined(__ANDROID__)
 	#define FINE_PLATFORM( a ) a
 	#define FINE_BIT( a ) a
 	#define FINE_BYTE_ORDER( a ) a


### PR DESCRIPTION
`_ANDROID` is left to guarantee stability of all of the previous builds.
Fix #30 

Signed-off-by: Valeriy Fedyunin <valery.fedyunin@abbyy.com>