### PR TITLE
Don't use CpuMathEngineCleanUp in DeinitializeNeoMathEngine

### DIFF
--- a/NeoMathEngine/src/CPU/CpuMathEngine.cpp
+++ b/NeoMathEngine/src/CPU/CpuMathEngine.cpp
@@ -292,8 +292,8 @@ void CpuMathEngineCleanUp()
 
 void DeinitializeNeoMathEngine()
 {
-	CpuMathEngineCleanUp();
 #ifdef NEOML_USE_MKL
+	mkl_free_buffers();
 	mkl_finalize();
 #endif
 }


### PR DESCRIPTION
Signed-off-by: Valeriy Fedyunin <valery.fedyunin@abbyy.com>