### PR TITLE
Support negative axes in Unsqueeze operator when opsetVer < 11

### DIFF
--- a/NeoOnnx/src/Operators/UnsqueezeOperator.cpp
+++ b/NeoOnnx/src/Operators/UnsqueezeOperator.cpp
@@ -63,7 +63,6 @@ void CUnsqueezeOperator::getAxes( const CTensorShape& inputShape, CFastArray<int
 	GetAttribute( "axes", axes );
 	for( int i = 0; i < axes.Size(); ++i ) {
 		if( axes[i] < 0 ) {
-			CheckOnnxProtocol( OpsetVersion >= 11, "negative axes indices are supported since v11", *this );
 			axes[i] += inputShape.Size() + axes.Size();
 		}
 	}


### PR DESCRIPTION


Signed-off-by: Valeriy Fedyunin <valery.fedyunin@abbyy.com>