### PR TITLE
Check for AVX2 instructions instead of AVX

### DIFF
--- a/NeoMathEngine/src/CPU/CPUInfo.h
+++ b/NeoMathEngine/src/CPU/CPUInfo.h
@@ -152,11 +152,18 @@ struct CCPUInfo {
 		Regs regs;
 		callCpuId( regs, 1 );
 
-		const unsigned int AvxAndFmaBits = ( 1 << 28 ) + ( 1 << 12 );
-		bool AvxAndFmaAreAvailable = ( regs.ecx & AvxAndFmaBits ) == AvxAndFmaBits;
+		const unsigned int fmaBit = ( 1 << 12 );
+		const bool fmaIsAvailable = ( regs.ecx & fmaBit ) == fmaBit;
+		if( !fmaIsAvailable ) {
+			return false;
+		}
 
+		callCpuId( regs, 7 );
 
-		return AvxAndFmaAreAvailable;
+		const unsigned int avx2Bit = ( 1 << 5 );
+		const bool avx2IsAvailable = ( regs.ebx & avx2Bit ) == avx2Bit;
+
+		return avx2IsAvailable;
 	}
 
 	static bool IsAvx512Available()

--- a/NeoMathEngine/src/CPU/CPUInfo.h
+++ b/NeoMathEngine/src/CPU/CPUInfo.h
@@ -158,7 +158,7 @@ struct CCPUInfo {
 			return false;
 		}
 
-		callCpuId( regs, 7 );
+		callCpuIdEx( regs, 7, 0 );
 
 		const unsigned int avx2Bit = ( 1 << 5 );
 		const bool avx2IsAvailable = ( regs.ebx & avx2Bit ) == avx2Bit;


### PR DESCRIPTION
Convolution contains AVX2 instructions.

Without this check `illegal instruction` occurs on some AMD processors (which have AVX+FMA and don't have AVX2)