### PR TITLE
Wrap input names in PyLayer

### DIFF
--- a/NeoML/Python/neoml/Dnn/Dnn.py
+++ b/NeoML/Python/neoml/Dnn/Dnn.py
@@ -270,6 +270,15 @@ class Layer:
         else:
             self._internal.disable_learning()    
     
+    @property
+    def input_names(self):
+        """Gets the layer inputs' names as a tuple of str.
+        """
+        return tuple(
+            self._internal.get_input_name(idx)
+            for idx in range(self._internal.get_input_count())
+        )
+
     def connect(self, layer, output_index=0, input_index=0):
         """Connects this layer to another.
         

--- a/NeoML/Python/neoml/Dnn/Dnn.py
+++ b/NeoML/Python/neoml/Dnn/Dnn.py
@@ -272,25 +272,19 @@ class Layer:
 
     @property
     def input_names(self):
-        """Gets the layer inputs' names as a tuple of str.
+        """Tuple in which i'th element contains the name of the layer, connected to the i'th inputs of `self`
+        """
+        return tuple(name for name, output_idx in self.input_links)
+
+    @property
+    def input_links(self):
+        """Tuple in which i'th element contains complete information about the link between i'th input layer
+        and `self` (layer name, output idx)
         """
         return tuple(
-            self._internal.get_input_name(idx)
+            (self._internal.get_input_name(idx), self._internal.get_input_output_idx(idx))
             for idx in range(self._internal.get_input_count())
         )
-
-    def get_input_output_idx(self, input_idx):
-        """Gets 'output idx' of input with 'input_idx'.
-
-        :param input_idx: the idx of input, whose output_idx is returned
-        :type input_idx: int
-        """
-        have_inputs = len(self.input_names)
-        is_idx_valid = (-have_inputs <= input_idx < have_inputs)
-
-        if not is_idx_valid:
-            raise KeyError(f"idx {input_idx} is invalid, have inputs({have_inputs}):{self.input_names}")
-        return self._internal.get_input_output_idx(input_idx)
 
 
     def connect(self, layer, output_index=0, input_index=0):

--- a/NeoML/Python/neoml/Dnn/Dnn.py
+++ b/NeoML/Python/neoml/Dnn/Dnn.py
@@ -269,7 +269,7 @@ class Layer:
             self._internal.enable_learning()
         else:
             self._internal.disable_learning()    
-    
+
     @property
     def input_names(self):
         """Gets the layer inputs' names as a tuple of str.
@@ -278,6 +278,20 @@ class Layer:
             self._internal.get_input_name(idx)
             for idx in range(self._internal.get_input_count())
         )
+
+    def get_input_output_idx(self, input_idx):
+        """Gets 'output idx' of input with 'input_idx'.
+
+        :param input_idx: the idx of input, whose output_idx is returned
+        :type input_idx: int
+        """
+        have_inputs = len(self.input_names)
+        is_idx_valid = (-have_inputs <= input_idx < have_inputs)
+
+        if not is_idx_valid:
+            raise KeyError(f"idx {input_idx} is invalid, have inputs({have_inputs}):{self.input_names}")
+        return self._internal.get_input_output_idx(input_idx)
+
 
     def connect(self, layer, output_index=0, input_index=0):
         """Connects this layer to another.

--- a/NeoML/Python/src/PyLayer.cpp
+++ b/NeoML/Python/src/PyLayer.cpp
@@ -38,10 +38,30 @@ void CPyLayer::Connect( CPyLayer &layer, int outputIndex, int inputIndex )
 	baseLayer->Connect( inputIndex, *layer.baseLayer, outputIndex );
 }
 
+std::string CPyLayer::GetInputName( int idx ) const
+{
+	const int inputCount = GetInputCount();
+	if( idx >= inputCount ) {
+		return std::string();
+	} else if ( idx >= 0 ) {
+		return baseLayer->GetInputName( idx );
+	} else {
+		if( idx + inputCount >= 0 ){
+		    // negative index is valid up to -inputCount
+			return baseLayer->GetInputName( idx + inputCount );
+		} else {
+		    // negative index is less than -inputCount
+			return std::string();
+		}
+	};
+}
+
 void InitializeLayer( py::module& m )
 {
 	py::class_<CPyLayer>(m, "Layer")
 		.def( "get_name", &CPyLayer::GetName, py::return_value_policy::reference )
+		.def( "get_input_count", &CPyLayer::GetInputCount, py::return_value_policy::reference )
+		.def( "get_input_name", &CPyLayer::GetInputName, py::return_value_policy::reference )
 		.def( "create_python_object", &CPyLayer::CreatePythonObject, py::return_value_policy::reference )
 		.def( "connect", &CPyLayer::Connect, py::return_value_policy::reference )
 		.def( "is_learning_enabled", &CPyLayer::IsLearningEnabled, py::return_value_policy::reference )

--- a/NeoML/Python/src/PyLayer.h
+++ b/NeoML/Python/src/PyLayer.h
@@ -32,6 +32,8 @@ public:
 	T* Layer() const { return dynamic_cast<T*>(baseLayer.Ptr()); }
 
 	std::string GetName() const { return std::string( baseLayer->GetName() ); }
+	int GetInputCount() const { return baseLayer->GetInputCount(); }
+	std::string GetInputName( int idx ) const;
 
 	void DisableLearning() { baseLayer->DisableLearning(); }
 	void EnableLearning() { baseLayer->EnableLearning(); }

--- a/NeoML/Python/src/PyLayer.h
+++ b/NeoML/Python/src/PyLayer.h
@@ -33,7 +33,8 @@ public:
 
 	std::string GetName() const { return std::string( baseLayer->GetName() ); }
 	int GetInputCount() const { return baseLayer->GetInputCount(); }
-	std::string GetInputName( int idx ) const;
+	std::string GetInputName( int inputIdx ) const;
+	int GetInputOutputIdx( int inputIdx ) const;
 
 	void DisableLearning() { baseLayer->DisableLearning(); }
 	void EnableLearning() { baseLayer->EnableLearning(); }

--- a/NeoML/Python/tests.py
+++ b/NeoML/Python/tests.py
@@ -2340,9 +2340,13 @@ class DnnTestCase(MultithreadedTestCase):
         argmax = neoml.Dnn.Argmax(source, name="argmax")
         sink = neoml.Dnn.Sink(argmax, "sink")
 
-        self.assertTrue(len(dnn.input_layers), 1)
-        self.assertTrue(len(dnn.layers), 3)
-        self.assertTrue(len(dnn.output_layers), 1)
+        self.assertEqual(len(dnn.input_layers), 1)
+        self.assertEqual(len(dnn.layers), 3)
+        self.assertEqual(len(dnn.output_layers), 1)
+
+        self.assertEqual(len(source.input_names), 0)
+        self.assertEqual(argmax.input_names, ('source',))
+        self.assertEqual(sink.input_names, ('argmax',))
 
         dir = tempfile.mkdtemp()
 
@@ -2356,9 +2360,9 @@ class DnnTestCase(MultithreadedTestCase):
         os.rmdir(dir)
 
         self.assertTrue(isinstance(dnn_loaded.solver, neoml.Dnn.AdaptiveGradient))
-        self.assertTrue(len(dnn_loaded.input_layers), 1)
-        self.assertTrue(len(dnn_loaded.layers), 3)
-        self.assertTrue(len(dnn_loaded.output_layers), 1)
+        self.assertEqual(len(dnn_loaded.input_layers), 1)
+        self.assertEqual(len(dnn_loaded.layers), 3)
+        self.assertEqual(len(dnn_loaded.output_layers), 1)
 
     def test_solver(self):
         math_engine = neoml.MathEngine.CpuMathEngine(1)

--- a/NeoML/Python/tests.py
+++ b/NeoML/Python/tests.py
@@ -2364,7 +2364,7 @@ class DnnTestCase(MultithreadedTestCase):
         self.assertEqual(len(dnn_loaded.layers), 3)
         self.assertEqual(len(dnn_loaded.output_layers), 1)
 
-    def test_input_output_idx(self):
+    def test_links(self):
         math_engine = neoml.MathEngine.CpuMathEngine(1)
 
         # y[N, 2] (X[N, 4]) = X[N, 2:] - X[N, :2]
@@ -2377,11 +2377,7 @@ class DnnTestCase(MultithreadedTestCase):
         # sub both inputs come from split_chan
         self.assertEqual(sub.input_names, (split_chan.name, split_chan.name))
         # but their order is inversed
-        self.assertEqual(sub.get_input_output_idx(0), 1)
-        self.assertEqual(sub.get_input_output_idx(1), 0)
-
-        with self.assertRaises(KeyError):
-            sub.get_input_output_idx(2)
+        self.assertEqual(sub.input_links, ((split_chan.name, 1), (split_chan.name, 0)))
 
     def test_solver(self):
         math_engine = neoml.MathEngine.CpuMathEngine(1)


### PR DESCRIPTION
Currently DNN graph structure is inaccessible from NeoML/Python - you can get the list of layers, but you can not read how these layers are connected with each other.
With input names getter it is possible to traverse the whole graph starting from sinks and retrieve it's structure.

It could be used in theory to plot the model, similar to [torchviz](https://github.com/szagoruyko/pytorchviz) or maybe even in a plugin for [netron.](https://github.com/lutzroeder/netron/blob/main/source/pytorch.py)

Also fixes incorrect `assertTrue` which are supposed to be `assertEqual`
