### PR TITLE
Set CUDA_ACHITECUTRE to native when undefined for NeoML/Python

### DIFF
--- a/NeoML/Python/CMakeLists.txt
+++ b/NeoML/Python/CMakeLists.txt
@@ -108,6 +108,11 @@ target_include_directories(PythonWrapper PRIVATE src)
 target_link_libraries(PythonWrapper PRIVATE NeoML)
 
 set_target_properties(PythonWrapper PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set_target_properties(PythonWrapper PROPERTIES CUDA_ARCHITECTURES native)
+endif()
+
 if(APPLE)
     set_target_properties(PythonWrapper PROPERTIES INSTALL_RPATH "@loader_path")
 endif()


### PR DESCRIPTION
Whenever I try to build NeoML/Python with `python setup.py install`, I get the following error:
```
...
-- Configuring done
CMake Error in CMakeLists.txt:
  CUDA_ARCHITECTURES is empty for target "PythonWrapper".
...
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

As far as I understand, this is because I do not specify CMAKE_CUDA_ARCHITECTURES variable. 
This PR sets it to [native](https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html) when variable is empty.
Somehow works for my CMake 3.18.
