### PR TITLE
Fix moduleDir in AvxDll.cpp when module path doesn't contain separator

### DIFF
--- a/NeoMathEngine/src/CPU/x86/AvxDll.cpp
+++ b/NeoMathEngine/src/CPU/x86/AvxDll.cpp
@@ -33,25 +33,26 @@ static std::string getModuleDir()
 	Dl_info dlInfo;
 	auto returnValue = dladdr( reinterpret_cast<void*>( getModuleDir ), &dlInfo );
 	ASSERT_EXPR( returnValue != 0 );
-		
+
 	constexpr char separator[] = { '/' };
 	const auto* dllPath = dlInfo.dli_fname;
 	auto it = std::find_end( dllPath, dllPath + strlen( dllPath ), separator, separator + 1 );
-		
-	result.assign( dllPath, it + 1 );
+	if( it != dllPath + strlen( dllPath ) ) {
+		result.assign( dllPath, it + 1 );
+	}
 
 #elif FINE_PLATFORM( FINE_WINDOWS )
 
 	static_assert( sizeof( TCHAR ) == sizeof( char ), "TCHAR is wide char type!" );
-		
+
 	std::vector<char> buffer;
 	DWORD copiedChars = 0;
-		
+
 	HMODULE handle;
 	auto returnValue = GetModuleHandleEx( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, 
 		reinterpret_cast<LPCSTR>( getModuleDir ), &handle );
 	PRESUME_EXPR( returnValue != 0 );
-		
+
 	do {
 		buffer.resize( buffer.size() + MAX_PATH );
 		copiedChars = GetModuleFileName( handle, buffer.data(), static_cast<DWORD>( buffer.size() ) );
@@ -60,7 +61,9 @@ static std::string getModuleDir()
 	constexpr char separator[] = {'\\'};
 	auto it = std::find_end( buffer.cbegin(), buffer.cbegin() + copiedChars, separator, separator + 1 );
 
-	result.assign( buffer.cbegin(), it + 1 );
+	if( it != buffer.cbegin() + copiedChars ) {
+		result.assign( buffer.cbegin(), it + 1 );
+	}
 
 #else
 	#error "Platform isn't supported!"


### PR DESCRIPTION
In WSL the `dli_name` may contain only module name (`libNeoMathEngine.so`).
In that case the `moduleDir()` function returns `"libNeoMathEngine.so\0"` and the following code tries to load `"libNeoMathEngine.so\0libNeoMathEngineAvx.so"` instead of `"libNeoMathEngineAvx.so"`.

After this fix `moduleDir()` returns empty string if separator wasn't found in `dli_name`

Signed-off-by: Valeriy Fedyunin <valery.fedyunin@abbyy.com>