### PR TITLE
Add TInterpolationCoords::AlignCornersOnnx

### DIFF
--- a/NeoMathEngine/include/NeoMathEngine/NeoMathEngine.h
+++ b/NeoMathEngine/include/NeoMathEngine/NeoMathEngine.h
@@ -58,14 +58,18 @@ enum TActivationFunction {
 //     - x_old - coordinate in array before the interpolation 
 //     - x_new - coordinate in array after the interpolation
 //     - old_size - size before the transformation
-//     - new_size - size after the transformation  (int(ratio * old_size))
+//     - new_size - size after the transformation  (int(scale * old_size))
 enum class TInterpolationCoords : int {
 	HalfPixel, // x_old = ( x_new + 0.5 ) / scale - 0.5
 	PytorchHalfPixel, // x_old = ( new_size > 1 ) ? ( x_new + 0.5 ) / scale - 0.5 : 0
-	AlignCorners, // x_old = x_new * ( old_size - 1) / ( new_size - 1 )
+	AlignCornersPyTorch, // x_old = x_new * ( old_size - 1) / ( new_size - 1 )
 	Asymmetric, // x_old = x_new / scale
+	AlignCornersOnnx, // x_old = x_new * ( old_size - 1 ) / ( scale * old_size - 1 )
 
-	Count
+	Count,
+
+	// Backward compatibility
+	AlignCorners = AlignCornersPyTorch
 };
 
 // Suppported rounding for coordinates

--- a/NeoMathEngine/src/CPU/CpuMathEngineDnn.cpp
+++ b/NeoMathEngine/src/CPU/CpuMathEngineDnn.cpp
@@ -1189,10 +1189,15 @@ static TCoordTransformer getCoordTransformer( TInterpolationCoords coords )
 				const int newSize = static_cast<int>( oldSize * scale );
 				return newSize > 1 ? ( newCoord + 0.5f ) / scale - 0.5f : 0.f;
 			};
-		case TInterpolationCoords::AlignCorners:
+		case TInterpolationCoords::AlignCornersPyTorch:
 			return []( int oldSize, float scale, int newCoord ) {
 				const int newSize = static_cast<int>( oldSize * scale );
-				return static_cast<float>( newCoord * ( oldSize - 1 ) ) / ( newSize - 1 );
+				return newSize > 1 ? static_cast<float>( newCoord * ( oldSize - 1 ) ) / ( newSize - 1 ) : 0.f;
+			};
+		case TInterpolationCoords::AlignCornersOnnx:
+			return []( int oldSize, float scale, int newCoord ) {
+				const float newSize = oldSize * scale;
+				return newSize > 1.f ? newCoord * ( oldSize - 1 ) / ( newSize - 1.f ) : 0.f;
 			};
 		default:
 			ASSERT_EXPR( false );

--- a/NeoMathEngine/src/GPU/CUDA/Kernels/CudaDnnKernels.h
+++ b/NeoMathEngine/src/GPU/CUDA/Kernels/CudaDnnKernels.h
@@ -794,11 +794,14 @@ __global__ void LinearInterpolationKernel( const float* data, float* result, int
 		case 1: // PytorchHalfPixel
 			xOld = ( newSize > 1 ) ? ( xNew + 0.5f ) / scale - 0.5f : 0.f;
 			break;
-		case 2: // AlignCorners
-			xOld = static_cast<float>( xNew * ( scaledAxis - 1 ) ) / ( newSize - 1 );
+		case 2: // AlignCornersPyTorch
+			xOld = newSize > 1 ? static_cast<float>( xNew * ( scaledAxis - 1 ) ) / ( newSize - 1 ) : 0.f;
 			break;
-		case 3:
+		case 3: // Asymmetric
 			xOld = xNew / scale;
+			break;
+		case 4:
+			xOld = scaledAxis * scale > 1.f ? xNew * ( scaledAxis - 1 ) / ( scaledAxis * scale - 1.f ) : 0.f;
 			break;
 	}
 

--- a/NeoMathEngine/test/src/inference/LinearInterpolationTest.cpp
+++ b/NeoMathEngine/test/src/inference/LinearInterpolationTest.cpp
@@ -47,11 +47,14 @@ static void naiveLinearInterpolation( TInterpolationCoords coords, TInterpolatio
 				case TInterpolationCoords::PytorchHalfPixel:
 					xOld = newSize > 1 ? ( xNew + 0.5f ) / scale - 0.5f : 0;
 					break;
-				case TInterpolationCoords::AlignCorners:
-					xOld = static_cast<float>( xNew * ( scaledAxis - 1 ) ) / ( newSize - 1 );
+				case TInterpolationCoords::AlignCornersPyTorch:
+					xOld = newSize > 1 ? static_cast<float>( xNew * ( scaledAxis - 1 ) ) / ( newSize - 1 ) : 0.f;
 					break;
 				case TInterpolationCoords::Asymmetric:
 					xOld = xNew / scale;
+					break;
+				case TInterpolationCoords::AlignCornersOnnx:
+					xOld = scaledAxis * scale > 1.f ? xNew * ( scaledAxis - 1 ) / ( scaledAxis * scale - 1.f ) : 0.f;
 					break;
 				default:
 					ASSERT_TRUE( false ) << "Unknown coordinate system";

--- a/NeoOnnx/src/Operators/ResizeOperator.cpp
+++ b/NeoOnnx/src/Operators/ResizeOperator.cpp
@@ -102,7 +102,7 @@ TInterpolationCoords CResizeOperator::getInterpolationCoords() const
 		return TInterpolationCoords::Asymmetric;
 	}
 
-	static_assert( static_cast<int>( TInterpolationCoords::Count ) == 4, "TInterpolationCoords::Count != 4" );
+	static_assert( static_cast<int>( TInterpolationCoords::Count ) == 5, "TInterpolationCoords::Count != 4" );
 	CString coordMode = "half_pixel";
 	GetAttribute( "coordinate_transformation_mode", coordMode );
 	if( coordMode == "half_pixel" ) {
@@ -110,7 +110,7 @@ TInterpolationCoords CResizeOperator::getInterpolationCoords() const
 	} else if( coordMode == "pytorch_half_pixel" ) {
 		return TInterpolationCoords::PytorchHalfPixel;
 	} else if( coordMode == "align_corners" ) {
-		return TInterpolationCoords::AlignCorners;
+		return TInterpolationCoords::AlignCornersOnnx;
 	} else if( coordMode == "asymmetric" ) {
 		return TInterpolationCoords::Asymmetric;
 	} else if( coordMode == "tf_half_pixel_for_nn" || coordMode == "tf_crop_and_resize" ) {


### PR DESCRIPTION
ONNX and PyTorch handle `align_corners` flag differently.

This PR does the following:

1. Fixes corner-case `new_size == 1`
2. Renames `AlignCorners` to `AlignCornersPyTorch` and adds `AlignCornersOnnx` which is fully compatible with Onnx