### PR TITLE
Corrected Undefined Behaviour on Bool Comparison

### DIFF
--- a/NeoML/src/TraditionalML/GradientBoostQSEnsemble.cpp
+++ b/NeoML/src/TraditionalML/GradientBoostQSEnsemble.cpp
@@ -662,7 +662,7 @@ inline bool CQSNodeAscending::Predicate( const CQSNode& first, const CQSNode& se
 	const bool firstIsInverted = HasFlag( first.PropertiesMask, PM_Inverted );
 	const bool secondIsInverted = HasFlag( second.PropertiesMask, PM_Inverted );
 	if( firstIsInverted != secondIsInverted ) {
-		return ( firstIsInverted < secondIsInverted );
+		return secondIsInverted;
 	}
 
 	const int firstTreeOrderIndex = treeOffsets[first.Tree] + first.Order;


### PR DESCRIPTION
Fix #755 

I want to explain my correction:

in the previous implementation:

```
 const bool firstIsInverted = HasFlag( first.PropertiesMask, PM_Inverted ); 
 const bool secondIsInverted = HasFlag( second.PropertiesMask, PM_Inverted ); 
 if( firstIsInverted != secondIsInverted ) { 
 	return ( firstIsInverted < secondIsInverted ); 
```

the returned value if the UB does not affect this is that if `firstIsInverted  == false` so the condition `firstIsInverted < secondIsInverted` was satisfied, this because `true` value is represented as a number different from zero.
Now if we analyze the first condition ` firstIsInverted != secondIsInverted`, and we coniugate it with `firstIsInverted  == false` the obvious result is that `secondIsInverted` is equal `true`. So we need just to return `secondIsInverted` variable.
The resulting code is:

```
 const bool firstIsInverted = HasFlag( first.PropertiesMask, PM_Inverted ); 
 const bool secondIsInverted = HasFlag( second.PropertiesMask, PM_Inverted ); 
 if( firstIsInverted != secondIsInverted ) { 
 	return secondIsInverted; 
```

I hope I was Clear.