### PR TITLE
Fix infinite Reshape in COnnxConvTransposeLayer

### DIFF
--- a/NeoML/src/Dnn/Layers/Onnx/OnnxConvTransposeLayer.cpp
+++ b/NeoML/src/Dnn/Layers/Onnx/OnnxConvTransposeLayer.cpp
@@ -38,9 +38,9 @@ void COnnxConvTransposeLayer::Reshape()
 
 	CBlobDesc origInputDesc;
 	if( !useExternalPadding ) {
-		SetPaddingHeight( totalPadding[0] ); //1d- convTranspose
+		paddingHeight = totalPadding[0]; //1d- convTranspose
 		if( OutputPadding().Size() == /*convDims*/2 ) { //2d- convTranspose
-			SetPaddingWidth( totalPadding[1] );
+			paddingWidth = totalPadding[1];
 		}
 	}
 


### PR DESCRIPTION
`SetPaddingHeihgt` calls `ForceReshape` which may cause this layer to reshape again if it's output used by multiple layers.