### PR TITLE
Use both BusID and DeviceID to identify CUDA GPU

### DIFF
--- a/NeoMathEngine/src/GPU/CUDA/CudaDevice.cpp
+++ b/NeoMathEngine/src/GPU/CUDA/CudaDevice.cpp
@@ -370,7 +370,7 @@ static void* captureDeviceSlots( int busId, int deviceId, int slotCount )
 	handle->Slots.reserve( slotCount );
 	for( int slotIndex = 0; slotIndex < CUDA_DEV_SLOT_COUNT; ++slotIndex ) {
 		if( file.CaptureSlot( slotIndex ) ) {
-			handle->Slots.push_back( CSlotHandle( busId, deviceId, slotIndex ) );
+			handle->Slots.push_back( slotIndex );
 			if( static_cast<int>( handle->Slots.size() ) == slotCount ) {
 				break;
 			}

--- a/NeoMathEngine/src/GPU/CUDA/CudaDevice.cpp
+++ b/NeoMathEngine/src/GPU/CUDA/CudaDevice.cpp
@@ -381,11 +381,11 @@ static void* captureDeviceSlots( int busId, int deviceId, int slotCount )
 	return handle.release();
 }
 
-static void releaseDeviceSlots( void* handle )
+static void releaseDeviceSlots( void* ptr )
 {
-	CSlotsHandle* handle = static_cast<CSlotsHandle*>( handle );\
+	CSlotsHandle* handle = static_cast<CSlotsHandle*>( ptr );
 
-	if( !handles->empty() ) {
+	if( !handle->Slots.empty() ) {
 		CDeviceFile file( handle->BusId, handle->DeviceId );
 		if( file.Open() ) {
 			for( const int& slotIndex : handle->Slots ) {
@@ -484,7 +484,7 @@ CCudaDevice* CaptureCudaDevice( int deviceNumber, size_t deviceMemoryLimit )
 
 		CCudaDevUsage dev;
 		dev.DevNum = i;
-		dev.FreeMemory = ( CUDA_DEV_SLOT_COUNT - getDeviceUsage( devProp.pciBusID ) ) * slotSize;
+		dev.FreeMemory = ( CUDA_DEV_SLOT_COUNT - getDeviceUsage( devProp.pciBusID, devProp.pciDeviceID ) ) * slotSize;
 		devs.push_back(dev);
 	}
 	// Sort the devices in decreasing free memory

--- a/NeoMathEngine/src/GPU/CUDA/CudaDevice.cpp
+++ b/NeoMathEngine/src/GPU/CUDA/CudaDevice.cpp
@@ -51,7 +51,7 @@ const int CUDA_DEV_SLOT_COUNT = 64;
 
 static inline std::string getCudaMutexName( int busId, int deviceId, int slotNum )
 {
-	return "Global\\AbbyyNeoMLCudaDev" + std::to_string( busId ) << "_" std::to_string( deviceId )
+	return "Global\\AbbyyNeoMLCudaDev" + std::to_string( busId ) + "_" + std::to_string( deviceId )
 		+ "_" + std::to_string( slotNum );
 }
 

--- a/NeoMathEngine/src/GPU/CUDA/CudaDevice.cpp
+++ b/NeoMathEngine/src/GPU/CUDA/CudaDevice.cpp
@@ -442,8 +442,6 @@ static CCudaDevice* captureSpecifiedCudaDevice( int deviceNumber, size_t deviceM
 	}
 
 	result->DeviceNumber = deviceNumber;
-	result->BusId = devProp.pciBusID;
-	result->DeviceId = devProp.pciDeviceID;
 	result->MemoryLimit = deviceMemoryLimit;
 	result->SharedMemoryLimit = 48 * 1024;
 

--- a/NeoMathEngine/src/GPU/CUDA/CudaDevice.cpp
+++ b/NeoMathEngine/src/GPU/CUDA/CudaDevice.cpp
@@ -345,7 +345,7 @@ struct CSlotsHandle {
 	int BusId;
 	int DeviceId;
 	std::vector<int> Slots;
-}
+};
 
 static void* captureDeviceSlots( int busId, int deviceId, int slotCount )
 {

--- a/NeoMathEngine/src/GPU/CUDA/CudaDevice.h
+++ b/NeoMathEngine/src/GPU/CUDA/CudaDevice.h
@@ -26,8 +26,6 @@ namespace NeoML {
 // CUDA device descriptor
 struct CCudaDevice : public CCrtAllocatedObject {
 	int DeviceNumber;
-	int BusId;
-	int DeviceId;
 	size_t MemoryLimit;
 	int SharedMemoryLimit;
 	int ThreadMaxCount;

--- a/NeoMathEngine/src/GPU/CUDA/CudaDevice.h
+++ b/NeoMathEngine/src/GPU/CUDA/CudaDevice.h
@@ -26,6 +26,7 @@ namespace NeoML {
 // CUDA device descriptor
 struct CCudaDevice : public CCrtAllocatedObject {
 	int DeviceNumber;
+	int BusId;
 	int DeviceId;
 	size_t MemoryLimit;
 	int SharedMemoryLimit;


### PR DESCRIPTION
There are 2 scenarios:

1. 2 physical GPUs. In this case both of them have `devProp.pciDeviceID == 0` but different `devProp.pciBusID` because they're physically located in different PCI slots on motherboard.
2. 2 virtual GPUs in the same physical GPU. In that case they have similar `devProp.pciBusID` but different `devProp.pciDeviceID` because they're different GPUs in the same PCI slot.

Scenario 1 has already been supported. This PR adds support for scenario 2.