### PR TITLE
Allow shape tensors in ONNX activation operators

### DIFF
--- a/NeoOnnx/src/Operators/ActivationOperator.cpp
+++ b/NeoOnnx/src/Operators/ActivationOperator.cpp
@@ -33,7 +33,6 @@ CActivationOperatorBase::CActivationOperatorBase( const onnx::NodeProto& onnxNod
 void CActivationOperatorBase::AddLayers( const CTensorArray& inputs, CDnn& dnn, CTensorArray& outputs ) const
 {
 	CheckNeoOnnxSupport( inputs[0] != nullptr, "Missing input", *this );
-	CheckNoShapeInputs( inputs );
 
 	CPtr<const CUserTensor> userInput = AsUserTensor( *inputs[0], Name() + "_Source", dnn );
 


### PR DESCRIPTION
Required for multihead attention from pytorch2