### PR TITLE
[NeoML] Less memory consumption 

### DIFF
--- a/NeoML/Python/src/PyCustomLossLayer.cpp
+++ b/NeoML/Python/src/PyCustomLossLayer.cpp
@@ -1,4 +1,4 @@
-/* Copyright © 2017-2021 ABBYY Production LLC
+/* Copyright © 2017-2024 ABBYY
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -60,15 +60,13 @@ static CArchive& operator >>( CArchive& archive, py::object& obj )
 
 //------------------------------------------------------------------------------------------------------------
 
-class CTempBlob : public CDnnBlob {
+// CPyTempDnnBlob does not own the handler data
+class CPyTempDnnBlob : public CDnnBlobView {
 public:
-	CTempBlob( IMathEngine& mathEngine, const CConstFloatHandle& data, const CBlobDesc& dataDesc );
+	CPyTempDnnBlob( IMathEngine& mathEngine, const CConstFloatHandle& data, const CBlobDesc& dataDesc ) :
+		CDnnBlobView( mathEngine, dataDesc, data )
+	{}
 };
-
-CTempBlob::CTempBlob( IMathEngine& mathEngine, const CConstFloatHandle& data, const CBlobDesc& dataDesc ) :
-	CDnnBlob( mathEngine, dataDesc, data, false )
-{
-}
 
 //------------------------------------------------------------------------------------------------------------
 
@@ -89,11 +87,11 @@ protected:
 
 		CPtr<CPyMathEngineOwner> mathEngineOwner = new CPyMathEngineOwner( &MathEngine(), false );
 
-		CPtr<const CDnnBlob> dataBlob = new CTempBlob( mathEngineOwner->MathEngine(), data, inputBlobs[0]->GetDesc() );
+		CPtr<const CDnnBlob> dataBlob = new CPyTempDnnBlob( mathEngineOwner->MathEngine(), data, inputBlobs[0]->GetDesc() );
 		CPtr<const CDnnBlob> var = tape.Variable( *dataBlob.Ptr() );
 		CPyBlob dataPyBlob( *mathEngineOwner, const_cast<CDnnBlob*>(var.Ptr()) );
 
-		CPtr<CDnnBlob> labelBlob( new CTempBlob( mathEngineOwner->MathEngine(), label, inputBlobs[1]->GetDesc() ) );
+		CPtr<CDnnBlob> labelBlob( new CPyTempDnnBlob( mathEngineOwner->MathEngine(), label, inputBlobs[1]->GetDesc() ) );
 		CPyBlob labelPyBlob( *mathEngineOwner, labelBlob );
 
 		CPtr<CDnnBlob> value;

--- a/NeoML/Python/src/PyDnnBlob.cpp
+++ b/NeoML/Python/src/PyDnnBlob.cpp
@@ -115,7 +115,10 @@ static CBlobDesc createBlobDesc( TBlobType type, std::initializer_list<int> dime
 	return desc;
 }
 
-class CPyDnnBlob : public CDnnBlob {
+//------------------------------------------------------------------------------------------------------------
+
+// CPyDnnBlob does not own the handler data
+class CPyDnnBlob : public CDnnBlobView {
 public:
 	CPyDnnBlob( IMathEngine& mathEngine, TBlobType type, std::initializer_list<int> dimension, py::buffer_info&& _info );
 	virtual ~CPyDnnBlob();
@@ -128,7 +131,7 @@ private:
 };
 
 CPyDnnBlob::CPyDnnBlob( IMathEngine& mathEngine, TBlobType type, std::initializer_list<int> dimension, py::buffer_info&& _info ) :
-	CDnnBlob( mathEngine, createBlobDesc( type, dimension ), CPyMemoryHandle( &mathEngine, _info.ptr ), false ),
+	CDnnBlobView( mathEngine, createBlobDesc( type, dimension ), CPyMemoryHandle( &mathEngine, _info.ptr ) ),
 	info( new py::buffer_info( std::move( _info ) ) )
 {
 }

--- a/NeoML/src/Dnn/AutoDiff.cpp
+++ b/NeoML/src/Dnn/AutoDiff.cpp
@@ -1,4 +1,4 @@
-/* Copyright © 2017-2021 ABBYY Production LLC
+/* Copyright © 2017-2024 ABBYY
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,14 +21,14 @@ limitations under the License.
 namespace NeoML {
 
 CTapeBlob::CTapeBlob( IGradientTape* _tape, const CDnnBlob& blob ) :
-	CDnnBlob( blob.GetMathEngine(), blob.GetDesc(), blob.GetMathEngine().HeapAlloc( blob.GetDataSize() * sizeof(float) ), true ),
+	CDnnBlob( blob.GetMathEngine(), blob.GetDesc(), blob.GetMathEngine().HeapAlloc( blob.GetDataSize() * sizeof(float) ) ),
 	tape( _tape )
 {
 	blob.GetMathEngine().VectorCopy( GetData(), blob.GetData(), blob.GetDataSize() );
 }
 
 CTapeBlob::CTapeBlob( IGradientTape* _tape, IMathEngine& mathEngine, const CBlobDesc& desc ) :
-	CDnnBlob( mathEngine, desc, mathEngine.HeapAlloc( desc.BlobSize() * sizeof(float) ), true ),
+	CDnnBlob( mathEngine, desc, mathEngine.HeapAlloc( desc.BlobSize() * sizeof(float) ) ),
 	tape( _tape )
 {
 }

--- a/NeoMathEngine/include/NeoMathEngine/MemoryHandle.inl
+++ b/NeoMathEngine/include/NeoMathEngine/MemoryHandle.inl
@@ -23,7 +23,7 @@ template<class T>
 inline void CTypedMemoryHandle<T>::SetValueAt( int index, T value ) const
 {
 	CTypedMemoryHandle<T> result = *this + index;
-	MathEngine->DataExchangeRaw( result, &value, sizeof( T ) );
+	GetMathEngine()->DataExchangeRaw( result, &value, sizeof( T ) );
 }
 
 template<class T>
@@ -31,7 +31,7 @@ inline T CTypedMemoryHandle<T>::GetValueAt( int index ) const
 {
 	char result[sizeof(T)];
 	CTypedMemoryHandle<T> source = *this + index;
-	MathEngine->DataExchangeRaw( result, source, sizeof( T ) );
+	GetMathEngine()->DataExchangeRaw( result, source, sizeof( T ) );
 	T* value = reinterpret_cast<T*>( &result );
 	return *value;
 }
@@ -39,14 +39,14 @@ inline T CTypedMemoryHandle<T>::GetValueAt( int index ) const
 template<class T>
 inline void CTypedMemoryHandle<T>::SetValue( T value ) const
 {
-	MathEngine->DataExchangeRaw( *this, &value, sizeof( T ) );
+	GetMathEngine()->DataExchangeRaw( *this, &value, sizeof( T ) );
 }
 
 template<class T>
 inline T CTypedMemoryHandle<T>::GetValue() const
 {
 	char result[sizeof(T)];
-	MathEngine->DataExchangeRaw( result, *this, sizeof( T ) );
+	GetMathEngine()->DataExchangeRaw( result, *this, sizeof( T ) );
 	T* value = reinterpret_cast<T*>( &result );
 	return *value;
 }

--- a/NeoMathEngine/include/NeoMathEngine/NeoMathEngine.h
+++ b/NeoMathEngine/include/NeoMathEngine/NeoMathEngine.h
@@ -1234,7 +1234,7 @@ public:
 	// This object should be destroyed using the standard delete operator after use.
 	virtual IPerformanceCounters* CreatePerformanceCounters( bool isTimeOnly = false ) const = 0;
 
-	// For Distributed only
+	// Methods group for the DnnDistributed execution only
 	virtual CMathEngineDistributedInfo GetDistributedInfo() { return CMathEngineDistributedInfo(); }
 	virtual void AllReduce( const CFloatHandle& handle, int size ) = 0;
 	virtual void Broadcast( const CFloatHandle& handle, int size, int root ) = 0;

--- a/NeoMathEngine/src/CPU/CpuMathEngine.cpp
+++ b/NeoMathEngine/src/CPU/CpuMathEngine.cpp
@@ -51,6 +51,7 @@ int NEOMATHENGINE_API FloatAlignment = CCPUInfo::DefineFloatAlignment();
 CCpuMathEngine::CCpuMathEngine( size_t _memoryLimit,
 		std::shared_ptr<CMultiThreadDistributedCommunicator> communicator,
 		const CMathEngineDistributedInfo& distributedInfo ) :
+	CMemoryEngineMixin( 0 ),
 	floatAlignment( FloatAlignment ),
 	communicator( communicator ),
 	distributedInfo( distributedInfo ),

--- a/NeoMathEngine/src/GPU/CUDA/CudaMathEngine.cu
+++ b/NeoMathEngine/src/GPU/CUDA/CudaMathEngine.cu
@@ -40,6 +40,7 @@ const int CudaMemoryAlignment = 4;
 
 CCudaMathEngine::CCudaMathEngine( const CCusparse* _cusparse, const CCublas* _cublas,
 		std::unique_ptr<CCudaDevice>& _device, int flags ) :
+	CMemoryEngineMixin( 0 ),
 	loader( CDllLoader::CUDA_DLL ),
 	cusparse( _cusparse ),
 	cublas( _cublas ),

--- a/NeoMathEngine/src/GPU/Metal/MetalMathEngine.mm
+++ b/NeoMathEngine/src/GPU/Metal/MetalMathEngine.mm
@@ -66,6 +66,7 @@ bool LoadMetalEngineInfo( CMathEngineInfo& info )
 const int MetalMemoryAlignment = 16;
 
 CMetalMathEngine::CMetalMathEngine( size_t memoryLimit ) :
+	CMemoryEngineMixin( 0 ),
 	queue( new CMetalCommandQueue() )
 {
 	ASSERT_EXPR( queue->Create() );

--- a/NeoMathEngine/src/GPU/Vulkan/VulkanMathEngine.cpp
+++ b/NeoMathEngine/src/GPU/Vulkan/VulkanMathEngine.cpp
@@ -69,6 +69,7 @@ bool LoadVulkanEngineInfo( const CVulkanDll& dll, std::vector< CMathEngineInfo, 
 constexpr int VulkanMemoryAlignment = 16;
 
 CVulkanMathEngine::CVulkanMathEngine( std::unique_ptr<const CVulkanDevice>& _device, size_t memoryLimit ) :
+	CMemoryEngineMixin( 0 ),
 	dllLoader( CDllLoader::VULKAN_DLL ),
 	device( std::move( _device ) ),
 	tmpImages( TVI_Count, nullptr )

--- a/NeoMathEngine/src/MemoryEngineMixin.cpp
+++ b/NeoMathEngine/src/MemoryEngineMixin.cpp
@@ -24,6 +24,25 @@ limitations under the License.
 
 namespace NeoML {
 
+size_t CMemoryEngineMixin::MathEngineEntitiesNumerator = 0;
+IMathEngine* CMemoryEngineMixin::MathEngineEntitiesArray[CMemoryHandle::MaxMathEngineEntities]{};
+
+// Get pointer to IMathEngine by the given current entity
+IMathEngine* GetMathEngineByIndex( size_t currentEntity )
+{
+	return CMemoryEngineMixin::MathEngineEntitiesArray[currentEntity];
+}
+
+// Get current entity from the given pointer to IMathEngine
+size_t GetIndexOfMathEngine( const IMathEngine* mathEngine )
+{
+	return ( mathEngine == nullptr )
+		? CMemoryHandle::MathEngineEntityInvalid
+		: static_cast<const CMemoryEngineMixin*>( mathEngine )->CurrentEntity;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+
 void CMemoryEngineMixin::InitializeMemory( IRawMemoryManager* _rawManager, size_t _memoryLimit, int _memoryAlignment,
 		bool _reuse, bool _hostStack )
 {

--- a/NeoMathEngine/src/MemoryEngineMixin.h
+++ b/NeoMathEngine/src/MemoryEngineMixin.h
@@ -59,6 +59,28 @@ protected:
 	std::unique_ptr<IStackAllocator, CStackAllocatorDeleter> HostStackAllocator; // stack allocator for regular memory
 
 	void CleanUpSpecial() override {}
+
+	// All below is need to avoid excess (8 bytes) field in each CMemoryHandler
+
+	// Special constructor
+	explicit CMemoryEngineMixin( int/*cannot be no call*/ ) :
+		CurrentEntity( ++MathEngineEntitiesNumerator )
+	{
+		ASSERT_EXPR( CurrentEntity < CMemoryHandle::MaxMathEngineEntities );
+		MathEngineEntitiesArray[CurrentEntity] = this;
+	}
+
+	// Generation for indices of all IMathEngine entities,
+	// Incremets evey moment new MathEngine created to generate its CurrentEntity value.
+	static size_t MathEngineEntitiesNumerator;
+	// Array for pointers to all entities of IMathEngine
+	// No cache ping-pong, because pointers are created once and never changes
+	static IMathEngine* MathEngineEntitiesArray[CMemoryHandle::MaxMathEngineEntities];
+	// Index of the current IMathEngine entity
+	const size_t CurrentEntity;
+
+	friend IMathEngine* GetMathEngineByIndex( size_t currentEntity );
+	friend size_t GetIndexOfMathEngine( const IMathEngine* mathEngine );
 };
 
 } // namespace NeoML

--- a/NeoMathEngine/src/MemoryPool.h
+++ b/NeoMathEngine/src/MemoryPool.h
@@ -81,11 +81,22 @@ private:
 	>;
 	// The information about a memory block address
 	struct CUsedInfo final {
-		size_t size = 0;
-		CMemoryBuffer* buffer = nullptr;
-
-		CUsedInfo( size_t _size = 0 ) : size( _size ) {}
+		// Either the size of heap memory block
+		CUsedInfo( size_t _size = 0 ) : size( _size | flag ) { ASSERT_EXPR( _size < flag ); }
+		// Or the address to memory block buffer
 		CUsedInfo( CMemoryBuffer* _buffer ) : buffer( _buffer ) {}
+
+		CMemoryBuffer* Buffer() const { return buffer; }
+		size_t Size() const { return size & ~flag; }
+		bool HasPoolBuffer() const { return !( size & flag ); }
+
+	private:
+		// Flag to signal that in unipn is a size, not a buffer
+		static constexpr size_t flag = size_t( 1 ) << ( sizeof( size_t ) * 8 - 1 );
+		union { // Either the size, or a buffer (8 bytes size structure)
+			size_t size;
+			CMemoryBuffer* buffer;
+		};
 	};
 	// The memory blocks addresses map
 	using TUsedAddressMap = std::unordered_map<


### PR DESCRIPTION
For x64 platform
1. All **CMemoryHandlers** sizes are decreased  24 bytes --> 16 bytes
2. Any **CMemoryHandlers** has been allocated, their corresponding structs sizes are decreased  32 bytes --> 16 bytes
3. Most **CDnnBlobs** sizes are decreased  80 bytes -->56 bytes