### PR TITLE
[NeoML] CDnnSolver uses strings instead layers pointers in maps for debug repeatable

### DIFF
--- a/NeoML/include/NeoML/Dnn/Dnn.h
+++ b/NeoML/include/NeoML/Dnn/Dnn.h
@@ -156,7 +156,10 @@ public:
 	//
 	// e.g. layer "InputHidden" inside of CLstmLayer named "LSTM", which is inside of CCompositeLayer named "Encoder"
 	// has path "Encoder/LSTM/InputHidden"
-	CString GetPath() const;
+	CString GetPath( const char* sep = "/" ) const;
+	// Path in form suitable for dnn->GetLayer( CArray<CString>& path );
+	// Returns an empty array if the path cannot be constructed.
+	void GetPath( CArray<CString>& path ) const;
 
 	// Connects this layer's inputNumber input to the specified layer's outputNumber output
 	virtual void Connect( int inputNumber, const char* layer, int outputNumber = 0 );
@@ -399,6 +402,8 @@ private:
 
 	// Set the 'dist' layer's paramBlobs to point to the data of this layer's paramBlobs
 	void transferParamsBlob(CBaseLayer& dist) const;
+	// Technical method for recursion in GetPath( CArray<CString>& path )
+	void getPath( CArray<CString>& path ) const;
 	// Switches the specified blobs into sequence processing mode
 	void switchBlobsToSequentialMode(CObjectArray<CDnnBlob>& blobs, TBlobCacheType cacheType, bool storeParent);
 	void switchBlobsToNonSequentialMode(CObjectArray<CDnnBlob>& blobs, TBlobCacheType cacheType, bool clear);

--- a/NeoML/include/NeoML/Dnn/Dnn.inl
+++ b/NeoML/include/NeoML/Dnn/Dnn.inl
@@ -1,4 +1,4 @@
-/* Copyright © 2017-2023 ABBYY
+/* Copyright © 2017-2024 ABBYY
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -56,9 +56,26 @@ inline bool CBaseLayer::IsBackwardNeeded() const
 	return isBackwardNeeded == BS_NeedsBackward;
 }
 
-inline CString CBaseLayer::GetPath() const
+inline CString CBaseLayer::GetPath( const char* sep ) const
 {
-	return dnn == nullptr || dnn->owner == nullptr ? name : dnn->owner->GetPath() + "/" + name;
+	return ( dnn == nullptr || dnn->owner == nullptr ) ? name : ( dnn->owner->GetPath( sep ) + sep + name );
+}
+
+inline void CBaseLayer::GetPath( CArray<CString>& path ) const
+{
+	path.DeleteAll();
+	getPath( path );
+}
+
+inline void CBaseLayer::getPath( CArray<CString>& path ) const
+{
+	if( dnn == nullptr ) {
+		return;
+	}
+	if( dnn->owner != nullptr ) {
+		dnn->owner->getPath( path );
+	}
+	path.Add( name );
 }
 
 inline void CBaseLayer::CheckLayerArchitecture( bool expr, const char* message ) const

--- a/NeoML/include/NeoML/Dnn/DnnSolver.h
+++ b/NeoML/include/NeoML/Dnn/DnnSolver.h
@@ -111,11 +111,17 @@ private:
 
 	// Telling the compiler that we intentionally using two-parameter Serialize instead of one declared in IObject
 	using IObject::Serialize;
-	// Convert maps from the previous serialization format
-	void loadPrevVersionDnnSolverMaps( CArchive& archive, const CDnn& dnn );
+	// Serialize load of the previous version of the dnn solver maps and convert them to new format
+	void serializeLoadMapsPrevVersion( CArchive& archive, const CDnn& dnn, int size );
+	// Serialize the layer's path array
+	void serializePath( CArchive& archive, CArray<CString>& path, const CBaseLayer* layer );
+	// Serialize the layer's parameters diff blobs sum struct
+	void serializeDiffBlobSum( CArchive& archive, CDiffBlobSum& blobsSum, const CBaseLayer* layer );
+	// Serialize the layer's gradient history
+	void serializeGradientHistory( CArchive& archive, const CString& layerPath );
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------------------------------------------------------------------
 
 // The macros for the internal name of a NeoML solver
 // If this macros is used when declaring a class, that class may be registered as a NeoML solver
@@ -132,7 +138,7 @@ void NEOML_API UnregisterSolverName( const std::type_info& typeInfo );
 
 void NEOML_API SerializeSolver( CArchive& archive, CDnn& dnn, CPtr<CDnnSolver>& solver);
 
-////////////////////////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------------------------------------------------------------------
 
 template<class T>
 class CSolverClassRegistrar {
@@ -156,7 +162,7 @@ inline CSolverClassRegistrar<T>::~CSolverClassRegistrar()
 	UnregisterSolverName( typeid( T ) );
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------------------------------------------------------------------
 
 // Stochastic gradient descent with moment
 class NEOML_API CDnnSimpleGradientSolver : public CDnnSolver {
@@ -198,7 +204,7 @@ private:
 	CPtr<CDnnBlob> tempVariables;
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------------------------------------------------------------------
 
 // Stochastic gradient descent with moment and adapting stride for each coordinate
 class NEOML_API CDnnAdaptiveGradientSolver : public CDnnSolver {
@@ -301,7 +307,7 @@ private:
 	CPtr<CDnnBlob> temporaryBlob;
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------------------------------------------------------------------
 
 // The optimizer that uses Nesterov moment
 // http://cs229.stanford.edu/proj2015/054_report.pdf (Algo 8).
@@ -408,7 +414,7 @@ private:
 	CPtr<CDnnBlob> mBarBlob;
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////
+//---------------------------------------------------------------------------------------------------------------------
 
 // Lamb optimizer.
 // https://arxiv.org/pdf/1904.00962.pdf
@@ -558,7 +564,8 @@ private:
 };
 
 template<typename TLayer>
-inline void CDnnLambGradientSolver::ExcludeWeightDecayLayer( int paramIndex ) {
+inline void CDnnLambGradientSolver::ExcludeWeightDecayLayer( int paramIndex )
+{
 	CPtr<TLayer> layer = new TLayer( MathEngine() );
 	ExcludeWeightDecayLayer( GetLayerClass( *layer ), ELNMT_LayerClass, paramIndex );
 }

--- a/NeoML/include/NeoML/Dnn/DnnSolver.h
+++ b/NeoML/include/NeoML/Dnn/DnnSolver.h
@@ -1,4 +1,4 @@
-/* Copyright © 2017-2023 ABBYY
+/* Copyright © 2017-2024 ABBYY
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public:
 	void SetMinMaxGradientClipping( float min, float max ) { clipGradientMin = min; clipGradientMax = max; }
 
 	// Serialize to archive
-	virtual void Serialize( CArchive& archive, CDnn& dnn );
+	virtual void Serialize( CArchive& archive, const CDnn& dnn );
 
 protected:
 	explicit CDnnSolver( IMathEngine& mathEngine );
@@ -86,18 +86,17 @@ private:
 	float clipGradientMax;
 
 	// The blobs sum
-	struct CDiffBlobSum {
-		CDiffBlobSum() : Count( 0 ) {}
-
-		CObjectArray<CDnnBlob> Sum; // the blobs sums
-		int Count; // the number of terms in each sum
+	struct CDiffBlobSum final {
+		const CBaseLayer* LayerOwner{}; // for the given layer
+		CObjectArray<CDnnBlob> Sum{}; // the blobs sums
+		int Count{}; // the number of terms in each sum
 	};
 
 	// The buffers used to add up the gradients from several AddDiff calls
-	CMap<CBaseLayer*, CDiffBlobSum> layerToParamDiffBlobsSum;
+	CMap<CString, CDiffBlobSum> layerToParamDiffBlobsSum;
 	// The buffers for storing gradients history and moment
 	// Used in the inheriting classes
-	CMap<CBaseLayer*, CObjectArray<CDnnBlob>> layerToGradientHistory;
+	CMap<CString, CObjectArray<CDnnBlob>> layerToGradientHistory;
 	// Layers which require reduction across distributed solver
 	CHashTable<CBaseLayer*> layersToReduce; // Fast check if layer is included already
 	CArray<CBaseLayer*> reduceOrder; // Correct order across all of the distributed nets
@@ -112,6 +111,8 @@ private:
 
 	// Telling the compiler that we intentionally using two-parameter Serialize instead of one declared in IObject
 	using IObject::Serialize;
+	// Convert maps from the previous serialization format
+	void loadPrevVersionDnnSolverMaps( CArchive& archive, const CDnn& dnn );
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -170,7 +171,7 @@ public:
 	bool IsInCompatibilityMode() const { return isInCompatibilityMode; }
 	void SetCompatibilityMode( bool compatibilityMode ) { isInCompatibilityMode = compatibilityMode; }
 
-	void Serialize( CArchive& archive, CDnn& dnn ) override;
+	void Serialize( CArchive& archive, const CDnn& dnn ) override;
 
 protected:
 	void TrainLayer( const CBaseLayer* layer, const CObjectArray<CDnnBlob>& paramBlobs, 
@@ -234,7 +235,7 @@ public:
 	// May be called only before training starts.
 	void EnableDecoupledWeightDecay( bool enable );
 
-	void Serialize( CArchive& archive, CDnn& dnn ) override;
+	void Serialize( CArchive& archive, const CDnn& dnn ) override;
 
 protected:
 	// Resets to the initial state
@@ -335,7 +336,7 @@ public:
 	// May be called only before training starts.
 	void EnableDecoupledWeightDecay( bool enable );
 
-	void Serialize( CArchive& archive, CDnn& dnn ) override;
+	void Serialize( CArchive& archive, const CDnn& dnn ) override;
 
 protected:
 	// Resets to the initial state
@@ -482,7 +483,7 @@ public:
 	bool GetUseNVLamb() const { return useNvLamb; }
 	void SetUseNVLamb( bool value ) { useNvLamb = value; }
 
-	void Serialize( CArchive& archive, CDnn& dnn ) override;
+	void Serialize( CArchive& archive, const CDnn& dnn ) override;
 
 protected:
 	void TrainLayer( const CBaseLayer* layer, const CObjectArray<CDnnBlob>& paramBlobs,
@@ -561,6 +562,5 @@ inline void CDnnLambGradientSolver::ExcludeWeightDecayLayer( int paramIndex ) {
 	CPtr<TLayer> layer = new TLayer( MathEngine() );
 	ExcludeWeightDecayLayer( GetLayerClass( *layer ), ELNMT_LayerClass, paramIndex );
 }
-
 
 } // namespace NeoML

--- a/NeoML/src/Dnn/DnnSolver.cpp
+++ b/NeoML/src/Dnn/DnnSolver.cpp
@@ -295,15 +295,6 @@ void CDnnSolver::clipGradients(const CObjectArray<CDnnBlob>& paramDiffBlobs)
 	}
 }
 
-static CString concatLayerPath( const CArray<CString>& path )
-{
-	CString layerPath = path[0];
-	for( int i = 1; i < path.Size(); ++i ) {
-		layerPath += layerPathSeparator + path[i];
-	}
-	return layerPath;
-}
-
 static const int DnnSolverVersion = 2;
 
 void CDnnSolver::Serialize( CArchive& archive, const CDnn& dnn )
@@ -331,7 +322,7 @@ void CDnnSolver::Serialize( CArchive& archive, const CDnn& dnn )
 			CArray<CString> path;
 			for( int i = 0; i < size; ++i ) {
 				serializePath( archive, path, /*layer*/nullptr );
-				const CString layerPath = concatLayerPath( path );
+				const CString layerPath = JoinStrings( path, layerPathSeparator );
 				serializeDiffBlobSum( archive, layerToParamDiffBlobsSum.CreateValue( layerPath ), dnn.GetLayer( path ) );
 
 				serializeGradientHistory( archive, layerPath );
@@ -385,7 +376,7 @@ void CDnnSolver::serializeLoadMapsPrevVersion( CArchive& archive, const CDnn& dn
 		if( layer != nullptr ) {
 			*layer = dnn.GetLayer( path );
 		}
-		return concatLayerPath( path );
+		return JoinStrings( path, layerPathSeparator );
 	};
 
 	for( int i = 0; i < size; ++i ) {

--- a/NeoML/src/Dnn/DnnSolver.cpp
+++ b/NeoML/src/Dnn/DnnSolver.cpp
@@ -295,7 +295,7 @@ void CDnnSolver::clipGradients(const CObjectArray<CDnnBlob>& paramDiffBlobs)
 	}
 }
 
-static const int DnnSolverVersion = 2;
+constexpr int DnnSolverVersion = 2;
 
 void CDnnSolver::Serialize( CArchive& archive, const CDnn& dnn )
 {
@@ -440,7 +440,7 @@ CDnnSimpleGradientSolver::CDnnSimpleGradientSolver( IMathEngine& mathEngine ) :
 {
 }
 
-static const int DnnSimpleGradientSolverVersion = 0;
+constexpr int DnnSimpleGradientSolverVersion = 0;
 
 void CDnnSimpleGradientSolver::Serialize( CArchive& archive, const CDnn& dnn )
 {
@@ -537,7 +537,7 @@ void CDnnAdaptiveGradientSolver::EnableDecoupledWeightDecay( bool enable )
 	isDecoupledWeightDecay = enable;
 }
 
-static const int DnnAdaptiveGradientSolver = 1;
+constexpr int DnnAdaptiveGradientSolver = 1;
 
 void CDnnAdaptiveGradientSolver::Serialize( CArchive& archive, const CDnn& dnn )
 {
@@ -713,7 +713,7 @@ void CDnnNesterovGradientSolver::EnableDecoupledWeightDecay( bool enable )
 	isDecoupledWeightDecay = enable;
 }
 
-static const int DnnNesterovGradientSolverVersion = 1;
+constexpr int DnnNesterovGradientSolverVersion = 1;
 
 void CDnnNesterovGradientSolver::Serialize( CArchive& archive, const CDnn& dnn )
 {
@@ -898,7 +898,7 @@ void CDnnLambGradientSolver::ExcludeBiasParamLayers()
 	ExcludeWeightDecayLayer<CTransposedConvLayer>( 1 );
 }
 
-static const int DnnLambGradientSolverVersion = 0;
+constexpr int DnnLambGradientSolverVersion = 0;
 
 void CDnnLambGradientSolver::Serialize( CArchive& archive, const CDnn& dnn )
 {


### PR DESCRIPTION
Please, merge before
* https://github.com/neoml-lib/neoml/pull/1086
* https://github.com/neoml-lib/neoml/pull/1081

---

Iteration over the CMap in CDnnSolver, which keys are memory pointers, leads to different behavior on dnn training on different runs. To avoid this problem, the strings are used instead of the raw pointers as CMap keys.