### PR TITLE
[NeoML] Create Distributed Inference 

### DIFF
--- a/NeoML/include/NeoML/Dnn/DnnDistributed.h
+++ b/NeoML/include/NeoML/Dnn/DnnDistributed.h
@@ -129,7 +129,7 @@ public:
 	// Creates `count` cpu models
 	// If `count` is 0 or less, then the models number equal to the number of available CPU cores
 	CDistributedInference( CDnn& dnn, int count );
-	CDistributedInference( IMathEngine& mathEngine, CArchive& archive, int count, int seed = 42 );
+	CDistributedInference( CArchive& archive, int count, int seed = 42 );
 
 	virtual ~CDistributedInference();
 
@@ -150,14 +150,17 @@ private:
 		CPointerArray<CDnn> Dnns; // Separate dnn for each thread
 		CString ErrorMessage; // Container for error if it happened
 	};
+
+	// The operator of worker threads
+	CPtrOwner<IThreadPool> threadPool;
+	// Own CPU Math Engine
+	CPtrOwner<IMathEngine> mathEngine;
 	// The random generator for original dnn, reference dnn stores their randoms for themselves
 	CRandom random;
-	// The operator of worker threads
-	IThreadPool* const threadPool;
 	// Each `RunOnce` task parameters
 	CParams params;
 
-	void initialize( IMathEngine& mathEngine, CArchive& archive, int threads_count );
+	void initialize( CArchive& archive, int threads_count );
 };
 
 } // namespace NeoML

--- a/NeoML/include/NeoML/Dnn/DnnDistributed.h
+++ b/NeoML/include/NeoML/Dnn/DnnDistributed.h
@@ -92,10 +92,10 @@ public:
 
 private:
 	const bool isCpu;
-	IThreadPool* threadPool;
+	IThreadPool* const threadPool;
 	CArray<IMathEngine*> mathEngines;
-	CArray<CRandom*> rands;
-	CArray<CDnn*> cnns;
+	CPointerArray<CRandom> rands;
+	CPointerArray<CDnn> cnns;
 	CArray<int> batchSize;
 	bool isFirstRun = true;
 	CString errorMessage;
@@ -126,9 +126,9 @@ public:
 	void GetLastBlob( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const;
 
 private:
-	struct CParams {
+	struct CParams final {
 		IDistributedDataset* Data = nullptr;
-		CArray<CDnn*> Dnns;
+		CPointerArray<CDnn> Dnns;
 		CString ErrorMessage;
 	};
 

--- a/NeoML/include/NeoML/Dnn/DnnDistributed.h
+++ b/NeoML/include/NeoML/Dnn/DnnDistributed.h
@@ -142,7 +142,9 @@ public:
 	// `layerName` should correspond to CSinkLayer
 	// NOTE: This blobs are part of the dnn and may be overwritten by next `RunOnce` task
 	//       Use it after each `RunOnce` task and copy them if you need to stare the result.
-	void GetLastBlob( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const;
+	void GetLastBlob( const CString& layerName, CObjectArray<const CDnnBlob>& blobs ) const;
+	// Returns copy last blobs of `layerName` for all models
+	void GetLastBlobCopy( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const;
 
 private:
 	struct CParams final {

--- a/NeoML/include/NeoML/Dnn/DnnDistributed.h
+++ b/NeoML/include/NeoML/Dnn/DnnDistributed.h
@@ -112,9 +112,8 @@ class NEOML_API CDistributedInference {
 public:
 	// Creates `count` cpu models
 	// If `count` is 0 or less, then the models number equal to the number of available CPU cores
-	CDistributedInference( CDnn& dnn, int count, IDistributedDataset& init_data );
-	CDistributedInference( IMathEngine& mathEngine, CArchive& archive, int count,
-		IDistributedDataset& init_data, int seed = 42 );
+	CDistributedInference( CDnn& dnn, int count );
+	CDistributedInference( IMathEngine& mathEngine, CArchive& archive, int count, int seed = 42 );
 
 	virtual ~CDistributedInference();
 
@@ -128,7 +127,6 @@ public:
 
 private:
 	struct CParams {
-		bool IsFirstRun = true;
 		IDistributedDataset* Data = nullptr;
 		CArray<CDnn*> Dnns;
 		CString ErrorMessage;
@@ -138,7 +136,7 @@ private:
 	IThreadPool* const threadPool;
 	CParams params;
 
-	void initialize( IMathEngine& mathEngine, CArchive& archive, int count, IDistributedDataset& data );
+	void initialize( IMathEngine& mathEngine, CArchive& archive, int threads_count );
 };
 
 } // namespace NeoML

--- a/NeoML/include/NeoML/Dnn/DnnDistributed.h
+++ b/NeoML/include/NeoML/Dnn/DnnDistributed.h
@@ -91,9 +91,7 @@ public:
 	//       `RunOnce`, `RunAndBackwardOnce` or `RunAndLearnOnce`.
 	//       Use it after each task and copy them if you need to store the result.
 	void GetLastBlob( const CString& layerName, CObjectArray<const CDnnBlob>& blobs ) const;
-	// Returns copy last blobs of `layerName` for all models
-	void GetLastBlobCopy( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const;
-	/// depreceted
+	/// deprecated
 	void GetLastBlob( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const;
 	// Save trained net
 	void Serialize( CArchive& archive );
@@ -107,7 +105,8 @@ private:
 	// If multi-threads on a CPU, it is an operator of worker threads
 	IThreadPool* const threadPool;
 	// Separate mathEngine for each thread or device both for CPU and GPU training
-	CArray<IMathEngine*> mathEngines; // (cannot use CPointerArray, as a raw array needs to initialize engines)
+	// Cannot use CPointerArray, as CreateDistributedCpuMathEngines requires a raw array to initialize engines
+	CArray<IMathEngine*> mathEngines;
 	// Separate random generator for each dnn in a thread
 	CPointerArray<CRandom> rands;
 	// Separate dnn for each thread
@@ -147,8 +146,6 @@ public:
 	// NOTE: This blobs are part of the dnn and may be overwritten by next `RunOnce` task
 	//       Use it after each `RunOnce` task and copy them if you need to stare the result.
 	void GetLastBlob( const CString& layerName, CObjectArray<const CDnnBlob>& blobs ) const;
-	// Returns copy last blobs of `layerName` for all models
-	void GetLastBlobCopy( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const;
 
 private:
 	// Params to transfer to all threads function

--- a/NeoML/include/NeoML/Dnn/DnnDistributed.h
+++ b/NeoML/include/NeoML/Dnn/DnnDistributed.h
@@ -50,12 +50,12 @@ class NEOML_API CDistributedTraining {
 public:
 	// Creates `count` cpu models
 	// If `count` is 0 or less, then the models number equal to the number of available CPU cores
-	CDistributedTraining( CDnn& dnn, int count,
+	CDistributedTraining( const CDnn& dnn, int count,
 		TDistributedInitializer initializer = TDistributedInitializer::Xavier, int seed = 42 );
 	CDistributedTraining( CArchive& archive, int count,
 		TDistributedInitializer initializer = TDistributedInitializer::Xavier, int seed = 42 );
 	// Creates gpu models, `devs` should contain numbers of using devices
-	CDistributedTraining( CDnn& dnn, const CArray<int>& cudaDevs,
+	CDistributedTraining( const CDnn& dnn, const CArray<int>& cudaDevs,
 		TDistributedInitializer initializer = TDistributedInitializer::Xavier, int seed = 42 );
 	CDistributedTraining( CArchive& archive, const CArray<int>& cudaDevs,
 		TDistributedInitializer initializer = TDistributedInitializer::Xavier, int seed = 42 );
@@ -90,6 +90,10 @@ public:
 	// NOTE: This blobs are part of the dnn and may be overwritten by next task of 
 	//       `RunOnce`, `RunAndBackwardOnce` or `RunAndLearnOnce`.
 	//       Use it after each task and copy them if you need to store the result.
+	void GetLastBlob( const CString& layerName, CObjectArray<const CDnnBlob>& blobs ) const;
+	// Returns copy last blobs of `layerName` for all models
+	void GetLastBlobCopy( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const;
+	/// depreceted
 	void GetLastBlob( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const;
 	// Save trained net
 	void Serialize( CArchive& archive );
@@ -128,7 +132,7 @@ class NEOML_API CDistributedInference {
 public:
 	// Creates `count` cpu models
 	// If `count` is 0 or less, then the models number equal to the number of available CPU cores
-	CDistributedInference( CDnn& dnn, int count );
+	CDistributedInference( const CDnn& dnn, int count );
 	CDistributedInference( CArchive& archive, int count, int seed = 42 );
 
 	virtual ~CDistributedInference();

--- a/NeoML/include/NeoML/Dnn/DnnDistributed.h
+++ b/NeoML/include/NeoML/Dnn/DnnDistributed.h
@@ -134,7 +134,7 @@ public:
 	virtual ~CDistributedInference();
 
 	// Gets the created models number
-	int GetModelCount() const { return params.Dnns.Size(); }
+	int GetModelCount() const { return threadParams.Dnns.Size(); }
 	// Runs the inference for all of the networks
 	// NOTE: Main thread waits while all tasks are done
 	void RunOnce( IDistributedDataset& data );
@@ -147,7 +147,8 @@ public:
 	void GetLastBlobCopy( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const;
 
 private:
-	struct CParams final {
+	// Params to transfer to all threads function
+	struct CThreadParams final {
 		IDistributedDataset* Data = nullptr; // Pointer to data for the inference for all dnns
 		CPointerArray<CDnn> Dnns; // Separate dnn for each thread
 		CString ErrorMessage; // Container for error if it happened
@@ -160,7 +161,7 @@ private:
 	// The random generator for original dnn, reference dnn stores their randoms for themselves
 	CRandom random;
 	// Each `RunOnce` task parameters
-	CParams params;
+	CThreadParams threadParams;
 
 	void initialize( CArchive& archive, int threads_count );
 };

--- a/NeoML/include/NeoML/Dnn/DnnDistributed.h
+++ b/NeoML/include/NeoML/Dnn/DnnDistributed.h
@@ -1,4 +1,5 @@
-/* Copyright © 2017-2023 ABBYY
+/* Copyright © 2017-2024 ABBYY
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -40,6 +41,8 @@ enum class TDistributedInitializer {
 	XavierUniform,
 	Uniform
 };
+
+//---------------------------------------------------------------------------------------------------------------------
 
 // Single process, multiple threads distributed training
 class NEOML_API CDistributedTraining {

--- a/NeoML/src/Dnn/BaseLayer.cpp
+++ b/NeoML/src/Dnn/BaseLayer.cpp
@@ -313,10 +313,14 @@ void CBaseLayer::transferParamsBlob( CBaseLayer& dist ) const
 			compositeFrom->GetLayer( layerName )->transferParamsBlob( *compositeTo->GetLayer( layerName ) );
 		}
 	} else {
-		dist.paramBlobs.SetSize( paramBlobs.Size() );
+		NeoAssertMsg( dist.paramBlobs.Size() == paramBlobs.Size(), "transferParamsBlob: It isn't a copy of the layer" );
+
+		NeoAssertMsg( !dist.IsLearnable() || paramBlobs.Size() > 0,
+			"transferParamsBlob: The origin dnn should be trained and reshaped to create a reference dnn" );
 		// Create reference copy of dist.paramBlobs with shared buffer
 		// Takes a pointer to parent's blob to access memory
 		for( int j = 0; j < dist.paramBlobs.Size(); ++j ) {
+			NeoAssertMsg( paramBlobs[j] != nullptr, "transferParamsBlob: All trainable paramBlobs should exist" );
 			dist.paramBlobs[j] = CDnnBlob::CreateWindowBlob( paramBlobs[j], paramBlobs[j]->GetDesc().BatchLength() );
 		}
 	}

--- a/NeoML/src/Dnn/Dnn.cpp
+++ b/NeoML/src/Dnn/Dnn.cpp
@@ -500,7 +500,6 @@ void CDnn::ForceRebuild()
 CDnn* CDnn::CreateReferenceDnn()
 {
 	CDnn* originalDnn = ( referenceDnnRegister.referenceCounter == -1 ) ? referenceDnnRegister.originalDnn : this;
-	originalDnn->reshape();
 
 	CDnnReferenceRegister referenceRegister( originalDnn );
 	CDnn* newDnn = new CDnn( *referenceRegister.originalRandom, mathEngine );

--- a/NeoML/src/Dnn/Dnn.cpp
+++ b/NeoML/src/Dnn/Dnn.cpp
@@ -499,6 +499,7 @@ void CDnn::ForceRebuild()
 
 CDnn* CDnn::CreateReferenceDnn()
 {
+	NeoAssertMsg( mathEngine.GetType() == MET_Cpu, "CreateReferenceDnn: Allowed only for CPU mathEngine" );
 	CDnn* originalDnn = ( referenceDnnRegister.referenceCounter == -1 ) ? referenceDnnRegister.originalDnn : this;
 
 	CDnnReferenceRegister referenceRegister( originalDnn );

--- a/NeoML/src/Dnn/DnnDistributed.cpp
+++ b/NeoML/src/Dnn/DnnDistributed.cpp
@@ -517,6 +517,7 @@ void CDistributedTraining::StoreDnn( CArchive& archive, int index, bool storeSol
 
 void CDistributedInference::initialize( IMathEngine& mathEngine, CArchive& archive, int threads_count )
 {
+	NeoAssertMsg( mathEngine.GetType() == MET_Cpu, "CDistributedInference: Allowed only for CPU mathEngine" );
 	initThreadGroupInfo();
 
 	NeoAssert( archive.IsLoading() );

--- a/NeoML/src/Dnn/DnnDistributed.cpp
+++ b/NeoML/src/Dnn/DnnDistributed.cpp
@@ -1,4 +1,5 @@
-/* Copyright © 2017-2023 ABBYY
+/* Copyright © 2017-2024 ABBYY
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -84,11 +85,13 @@ void initThreadGroupInfo()
 	}
 }
 
-#else // FINE_PLATFORM( FINE_WINDOWS )
+#else  // !FINE_PLATFORM( FINE_WINDOWS )
 
 static void initThreadGroupInfo() {}
 
-#endif
+#endif // !FINE_PLATFORM( FINE_WINDOWS )
+
+//---------------------------------------------------------------------------------------------------------------------
 
 // RAII switcher of current thread's group
 class CThreadGroupSwitcher {
@@ -128,9 +131,9 @@ public:
 
 private:
 #if FINE_PLATFORM( FINE_WINDOWS )
-	bool isAffinitySet;
-	GROUP_AFFINITY prevAffinity;
-#endif
+	bool isAffinitySet = false;
+	GROUP_AFFINITY prevAffinity{};
+#endif // FINE_PLATFORM( FINE_WINDOWS )
 };
 
 static CPtr<CDnnInitializer> createInitializer( TDistributedInitializer type, CRandom& random )
@@ -147,6 +150,8 @@ static CPtr<CDnnInitializer> createInitializer( TDistributedInitializer type, CR
 	}
 	return nullptr;
 }
+
+//---------------------------------------------------------------------------------------------------------------------
 
 void CDistributedTraining::initialize( CArchive& archive, int count, TDistributedInitializer initializer, int seed )
 {
@@ -328,7 +333,7 @@ void CDistributedTraining::RunOnce( IDistributedDataset& data )
 			cnns[threadIndex]->GetMathEngine().AbortDistributed();
 			delete e;
 		}
-#endif
+#endif // NEOML_USE_FINEOBJ
 	};
 	NEOML_NUM_THREADS( *threadPool, &function_params, f );
 
@@ -385,7 +390,7 @@ void CDistributedTraining::RunAndBackwardOnce( IDistributedDataset& data )
 			cnns[threadIndex]->GetMathEngine().AbortDistributed();
 			delete e;
 		}
-#endif
+#endif // NEOML_USE_FINEOBJ
 	};
 	NEOML_NUM_THREADS( *threadPool, &function_params, f );
 
@@ -448,7 +453,7 @@ void CDistributedTraining::Train()
 			cnns[threadIndex]->GetMathEngine().AbortDistributed();
 			delete e;
 		}
-#endif
+#endif // NEOML_USE_FINEOBJ
 	};
 	NEOML_NUM_THREADS( *threadPool, &function_params, f );
 

--- a/NeoML/src/Dnn/DnnDistributed.cpp
+++ b/NeoML/src/Dnn/DnnDistributed.cpp
@@ -502,15 +502,7 @@ void CDistributedTraining::GetLastBlob( const CString& layerName, CObjectArray<c
 	}
 }
 
-void CDistributedTraining::GetLastBlobCopy( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const
-{
-	blobs.SetSize( cnns.Size() );
-	for( int i = 0; i < cnns.Size(); ++i ) {
-		blobs[i] = CheckCast<const CSinkLayer>( cnns[i]->GetLayer( layerName ) )->GetBlob()->GetCopy();
-	}
-}
-
-// depreceted
+// deprecated
 void CDistributedTraining::GetLastBlob( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const
 {
 	blobs.SetSize( cnns.Size() );
@@ -632,14 +624,6 @@ void CDistributedInference::GetLastBlob( const CString& layerName, CObjectArray<
 	blobs.SetSize( threadParams.Dnns.Size() );
 	for( int i = 0; i < threadParams.Dnns.Size(); ++i ) {
 		blobs[i] = CheckCast<const CSinkLayer>( threadParams.Dnns[i]->GetLayer( layerName ) )->GetBlob();
-	}
-}
-
-void CDistributedInference::GetLastBlobCopy( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const
-{
-	blobs.SetSize( threadParams.Dnns.Size() );
-	for( int i = 0; i < threadParams.Dnns.Size(); ++i ) {
-		blobs[i] = CheckCast<const CSinkLayer>( threadParams.Dnns[i]->GetLayer( layerName ) )->GetBlob()->GetCopy();
 	}
 }
 

--- a/NeoML/src/Dnn/DnnDistributed.cpp
+++ b/NeoML/src/Dnn/DnnDistributed.cpp
@@ -610,11 +610,19 @@ void CDistributedInference::RunOnce( IDistributedDataset& data )
 	params.Data = nullptr;
 }
 
-void CDistributedInference::GetLastBlob( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const
+void CDistributedInference::GetLastBlob( const CString& layerName, CObjectArray<const CDnnBlob>& blobs ) const
 {
 	blobs.SetSize( params.Dnns.Size() );
 	for( int i = 0; i < params.Dnns.Size(); ++i ) {
 		blobs[i] = CheckCast<const CSinkLayer>( params.Dnns[i]->GetLayer( layerName ) )->GetBlob();
+	}
+}
+
+void CDistributedInference::GetLastBlobCopy( const CString& layerName, CObjectArray<CDnnBlob>& blobs ) const
+{
+	blobs.SetSize( params.Dnns.Size() );
+	for( int i = 0; i < params.Dnns.Size(); ++i ) {
+		blobs[i] = CheckCast<const CSinkLayer>( params.Dnns[i]->GetLayer( layerName ) )->GetBlob()->GetCopy();
 	}
 }
 

--- a/NeoML/test/src/DnnDistributedTest.cpp
+++ b/NeoML/test/src/DnnDistributedTest.cpp
@@ -273,7 +273,7 @@ TEST( CDnnDistributedTest, DnnDistributedInferenceArchived )
 	}
 
 	{ // Check dnn constructor
-		CDistributedInference distributed( dnn, /*count*/0, dataset );
+		CDistributedInference distributed( dnn, /*count*/0 );
 		EXPECT_LT( 0, distributed.GetModelCount() );
 		EXPECT_EQ( GetAvailableCpuCores(), distributed.GetModelCount() );
 
@@ -296,7 +296,7 @@ TEST( CDnnDistributedTest, DnnDistributedInferenceArchived )
 	{ // Check archive constructor
 		CArchiveFile file( archiveName, CArchive::load, GetPlatformEnv() );
 		CArchive archive( &file, CArchive::load );
-		CDistributedInference distributed( mathEngine, archive, /*count*/4, dataset, /*seed*/42 );
+		CDistributedInference distributed( mathEngine, archive, /*count*/4, /*seed*/42 );
 		EXPECT_EQ( 4, distributed.GetModelCount() );
 
 		distributed.RunOnce( dataset );

--- a/NeoML/test/src/DnnDistributedTest.cpp
+++ b/NeoML/test/src/DnnDistributedTest.cpp
@@ -273,17 +273,17 @@ TEST( CDnnDistributedTest, DnnDistributedInferenceArchived )
 
 		distributed.RunOnce( dataset );
 
-		CObjectArray<CDnnBlob> blobs;
+		CObjectArray<const CDnnBlob> blobs;
 		distributed.GetLastBlob( "sink", blobs );
 		for( int i = 0; i < blobs.Size(); ++i ) {
-			EXPECT_TRUE( CompareBlobs( *( blobs[i] ), *expected ) );
+			EXPECT_TRUE( CompareBlobs( const_cast<CDnnBlob&>( *( blobs[i] ) ), *expected ) );
 		}
 
 		distributed.RunOnce( dataset );
 
 		distributed.GetLastBlob( "sink", blobs );
 		for( int i = 0; i < blobs.Size(); ++i ) {
-			EXPECT_TRUE( CompareBlobs( *( blobs[i] ), *expected ) );
+			EXPECT_TRUE( CompareBlobs( const_cast<CDnnBlob&>( *( blobs[i] ) ), *expected ) );
 		}
 	}
 
@@ -295,10 +295,10 @@ TEST( CDnnDistributedTest, DnnDistributedInferenceArchived )
 
 		distributed.RunOnce( dataset );
 
-		CObjectArray<CDnnBlob> blobs;
+		CObjectArray<const CDnnBlob> blobs;
 		distributed.GetLastBlob( "sink", blobs );
 		for( int i = 0; i < blobs.Size(); ++i ) {
-			EXPECT_TRUE( CompareBlobs( *( blobs[i] ), *expected ) );
+			EXPECT_TRUE( CompareBlobs( const_cast<CDnnBlob&>( *( blobs[i] ) ), *expected ) );
 		}
 	}
 }

--- a/NeoML/test/src/DnnDistributedTest.cpp
+++ b/NeoML/test/src/DnnDistributedTest.cpp
@@ -1,4 +1,4 @@
-/* Copyright © 2021-2023 ABBYY
+/* Copyright © 2021-2024 ABBYY
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,150 +23,137 @@ limitations under the License.
 using namespace NeoML;
 using namespace NeoMLTest;
 
+namespace NeoMLTest {
+
 class CCustomDataset : public IDistributedDataset {
 public:
 	CCustomDataset( int _inputSize, int _labelSize )
-		: inputSize( _inputSize ), labelSize( _labelSize )  {};
+		: inputSize( _inputSize ), labelSize( _labelSize ) {}
 
-	int SetInputBatch( CDnn& cnn, int ) override
+	int SetInputBatch( CDnn& dnn, int ) override
 	{
 		CArray<float> inArr;
 		inArr.Add( 1, inputSize );
-		CPtr<CDnnBlob> in = CDnnBlob::CreateTensor( cnn.GetMathEngine(), CT_Float, { 1, 1, 1, 1, 1, 1, inputSize} );
+		CPtr<CDnnBlob> in = CDnnBlob::CreateTensor( dnn.GetMathEngine(), CT_Float, { 1, 1, 1, 1, 1, 1, inputSize } );
 		in->CopyFrom( inArr.GetPtr() );
 		CArray<float> labelArr;
 		labelArr.Add( 1, labelSize );
-		CPtr<CDnnBlob> labels = CDnnBlob::CreateTensor( cnn.GetMathEngine(), CT_Float, { 1, 1, 1, 1, 1, 1, labelSize } );
+		CPtr<CDnnBlob> labels = CDnnBlob::CreateTensor( dnn.GetMathEngine(), CT_Float, { 1, 1, 1, 1, 1, 1, labelSize } );
 		labels->CopyFrom( labelArr.GetPtr() );
-		CheckCast<CSourceLayer>( cnn.GetLayer( "in" ) )->SetBlob( in );
-		CheckCast<CSourceLayer>( cnn.GetLayer( "label" ) )->SetBlob( labels );
+		CheckCast<CSourceLayer>( dnn.GetLayer( "data" ) )->SetBlob( in );
+		CheckCast<CSourceLayer>( dnn.GetLayer( "label" ) )->SetBlob( labels );
 		return 1;
 	}
 
-	~CCustomDataset(){};
-
 private:
-	int inputSize;
-	int labelSize;
+	const int inputSize;
+	const int labelSize;
 };
 
-static void buildDnn( CDnn& cnn, int outputSize )
+static void buildDnn( CDnn& dnn, int outputSize )
 {
-	CPtr<CSourceLayer> dataLayer = new CSourceLayer( cnn.GetMathEngine() );
-	dataLayer->SetName( "in" );
-	cnn.AddLayer( *dataLayer );
+	CPtr<CSourceLayer> data = Source( dnn, "data" );
+	CPtr<CSourceLayer> label = Source( dnn, "label" );
 
-	CPtr<CFullyConnectedLayer> full = new CFullyConnectedLayer( cnn.GetMathEngine() );
-	full->SetNumberOfElements( outputSize );
-	full->SetName( "full" );
-	full->SetZeroFreeTerm( true );
-	full->Connect( *dataLayer );
-	cnn.AddLayer( *full );
+	CPtr<CFullyConnectedLayer> full = FullyConnected( outputSize, /*freeTerm*/true )( "full", data.Ptr() );
+	CPtr<CEuclideanLossLayer> loss = EuclideanLoss()( "loss", full.Ptr(), label.Ptr() );
 
-	CPtr<CSourceLayer> label = new CSourceLayer( cnn.GetMathEngine() );
-	label->SetName( "label" );
-	cnn.AddLayer( *label );
+	( void ) Sink( full.Ptr(), "sink" );
 
-	CPtr<CEuclideanLossLayer> loss = new CEuclideanLossLayer( cnn.GetMathEngine() );
-	loss->SetName( "loss" );
-	loss->Connect( 0, *full );
-	loss->Connect( 1, *label );
-	cnn.AddLayer( *loss );
-
-	CPtr<CSinkLayer> out = new CSinkLayer( cnn.GetMathEngine() );
-	out->SetName( "sink" );
-	out->Connect( *full );
-	cnn.AddLayer( *out );
-
-	CPtr<CDnnAdaptiveGradientSolver> solver = new CDnnAdaptiveGradientSolver( cnn.GetMathEngine() );
-	cnn.SetSolver( solver.Ptr() );
+	CPtr<CDnnSolver> solver = new CDnnAdaptiveGradientSolver( dnn.GetMathEngine() );
+	dnn.SetSolver( solver.Ptr() );
 }
+
+static constexpr int inputSize = 1000;
+static constexpr int outputSize = 5;
+
+} // namespace NeoMLTest
+
+//---------------------------------------------------------------------------------------------------------------------
 
 TEST( CDnnDistributedTest, DnnDistributedNoArchiveTest )
 {
 	std::unique_ptr<IMathEngine> mathEngine( CreateCpuMathEngine( /*memoryLimit*/0u ) );
 	CRandom rand( 42 );
 
-	int inputSize = 1000;
-	int outputSize = 5;
-	CDnn cnn( rand, *mathEngine );
-	buildDnn( cnn, outputSize );
+	CDnn dnn( rand, *mathEngine );
+	buildDnn( dnn, outputSize );
 
-	CDistributedTraining distributed( cnn, 2 );
+	CDistributedTraining distributed( dnn, 2 );
 	CCustomDataset dataset( inputSize, outputSize );
 	distributed.RunOnce( dataset );
 	distributed.RunAndLearnOnce( dataset );
 
 	CObjectArray<CDnnBlob> blobs;
 	distributed.GetLastBlob( "sink", blobs );
-	for( int i = 0; i < 2; i++ ) {
-		ASSERT_EQ( outputSize, blobs[i]->GetDataSize() );
+	EXPECT_EQ( outputSize, blobs[0]->GetDataSize() );
+	for( int i = 1; i < 2; i++ ) {
+		EXPECT_EQ( outputSize, blobs[i]->GetDataSize() );
+		EXPECT_TRUE( CompareBlobs( *( blobs[0] ), *( blobs[i] ) ) );
 	}
+
 	CArray<float> losses;
 	distributed.GetLastLoss( "loss", losses );
-	ASSERT_EQ( 2, losses.Size() );
-	ASSERT_EQ( losses[0], losses[1] );
-	ASSERT_EQ( 2, distributed.GetModelCount() );
+	EXPECT_EQ( 2, losses.Size() );
+	EXPECT_EQ( losses[0], losses[1] );
+	EXPECT_EQ( 2, distributed.GetModelCount() );
 }
 
 TEST( CDnnDistributedTest, DnnDistributedArchiveTest )
 {
 	std::unique_ptr<IMathEngine> mathEngine( CreateCpuMathEngine( /*memoryLimit*/0u ) );
+
 	CRandom rand( 42 );
+	CDnn dnn( rand, *mathEngine );
+	buildDnn( dnn, outputSize );
 
-	int inputSize = 1000;
-	int outputSize = 5;
-	CDnn cnn( rand, *mathEngine );
-	buildDnn( cnn, outputSize );
-
+	CCustomDataset dataset( inputSize, outputSize );
 	CString archiveName = "distributed";
 	{
-		CArchiveFile storeFile( archiveName, CArchive::store, GetPlatformEnv() );
-		CArchive storeArchive( &storeFile, CArchive::SD_Storing );
-		storeArchive.Serialize( cnn );
+		CArchiveFile file( archiveName, CArchive::store, GetPlatformEnv() );
+		CArchive archive( &file, CArchive::SD_Storing );
+		archive.Serialize( dnn );
 	}
 
 	CArchiveFile archiveFile( archiveName, CArchive::load, GetPlatformEnv() );
-	CArchive archive( &archiveFile, CArchive::SD_Loading );
+	CArchive archive( &archiveFile, CArchive::load );
 	CDistributedTraining distributed( archive, 2 );
-	CCustomDataset dataset( inputSize, outputSize );
+	EXPECT_EQ( 2, distributed.GetModelCount() );
 	archive.Close();
 	archiveFile.Close();
-	CPtr<CDnnSolver> solver = new CDnnAdaptiveGradientSolver( cnn.GetMathEngine() );
 
 	{
-		cnn.SetSolver( solver.Ptr() );
-		CArchiveFile storeFile( archiveName, CArchive::store, GetPlatformEnv() );
-		CArchive storeArchive( &storeFile, CArchive::SD_Storing );
-		SerializeSolver( storeArchive, cnn, solver );
-	}
+		CPtr<CDnnSolver> solver = new CDnnAdaptiveGradientSolver( dnn.GetMathEngine() );
+		dnn.SetSolver( solver.Ptr() );
 
+		CArchiveFile storeFile( archiveName, CArchive::store, GetPlatformEnv() );
+		CArchive storeArchive( &storeFile, CArchive::store );
+		SerializeSolver( storeArchive, dnn, solver );
+	}
 	{
 		CArchiveFile loadFile( archiveName, CArchive::load, GetPlatformEnv() );
-		CArchive loadArchive( &loadFile, CArchive::SD_Loading );
+		CArchive loadArchive( &loadFile, CArchive::load );
 		distributed.SetSolver( loadArchive );
 	}
 
 	distributed.RunAndBackwardOnce( dataset );
 	distributed.Train();
+
 	CArray<float> losses;
 	distributed.GetLastLoss( "loss", losses );
-	ASSERT_EQ( 2, losses.Size() );
-	ASSERT_EQ( losses[0], losses[1] );
-	ASSERT_EQ( 2, distributed.GetModelCount() );
+	EXPECT_EQ( 2, losses.Size() );
+	EXPECT_EQ( losses[0], losses[1] );
 }
 
 TEST( CDnnDistributedTest, DnnDistributedSerializeTest )
 {
 	std::unique_ptr<IMathEngine> mathEngine( CreateCpuMathEngine( /*memoryLimit*/0u ) );
+
 	CRandom rand( 42 );
+	CDnn dnn( rand, *mathEngine );
+	buildDnn( dnn, outputSize );
 
-	int inputSize = 1000;
-	int outputSize = 5;
-	CDnn cnn( rand, *mathEngine );
-	buildDnn( cnn, outputSize );
-
-	CDistributedTraining distributed( cnn, 3 );
+	CDistributedTraining distributed( dnn, 3 );
 	CCustomDataset dataset( inputSize, outputSize );
 	distributed.RunAndLearnOnce( dataset );
 	distributed.RunOnce( dataset );
@@ -192,23 +179,23 @@ TEST( CDnnDistributedTest, DnnDistributedSerializeTest )
 	dataset.SetInputBatch( serializedCnn, 0 );
 	serializedCnn.RunOnce();
 	float loss = static_cast< CLossLayer* >( serializedCnn.GetLayer( "loss" ).Ptr() )->GetLastLoss();
-	ASSERT_EQ( loss, losses[0] );
+	EXPECT_EQ( loss, losses[0] );
 
 	CArray<float> distributedWeights;
 	CPtr<CDnnBlob> weightsBlob = static_cast< CFullyConnectedLayer* >( serializedCnn.GetLayer( "full" ).Ptr() )->GetWeightsData();
 	distributedWeights.SetSize( weightsBlob->GetDataSize() );
 	weightsBlob->CopyTo( distributedWeights.GetPtr() );
 
-	dataset.SetInputBatch( cnn, 0 );
-	cnn.RunAndLearnOnce();
+	dataset.SetInputBatch( dnn, 0 );
+	dnn.RunAndLearnOnce();
 	CArray<float> weights;
-	weightsBlob = static_cast< CFullyConnectedLayer* >( cnn.GetLayer( "full" ).Ptr() )->GetWeightsData();
+	weightsBlob = static_cast< CFullyConnectedLayer* >( dnn.GetLayer( "full" ).Ptr() )->GetWeightsData();
 	weights.SetSize( weightsBlob->GetDataSize() );
 	weightsBlob->CopyTo( weights.GetPtr() );
 
-	ASSERT_EQ( weights.Size(), distributedWeights.Size() );
+	EXPECT_EQ( weights.Size(), distributedWeights.Size() );
 	for( int i = 0; i < weights.Size(); i++ ) {
-		ASSERT_NEAR( weights[i], distributedWeights[i], 1e-4 );
+		EXPECT_NEAR( weights[i], distributedWeights[i], 1e-4 );
 	}
 }
 
@@ -217,12 +204,11 @@ TEST( CDnnDistributedTest, DnnDistributedAutoThreadCountTest )
 	std::unique_ptr<IMathEngine> mathEngine( CreateCpuMathEngine( /*memoryLimit*/0u ) );
 	CRandom rand( 42 );
 
-	const int outputSize = 5;
-	CDnn cnn( rand, *mathEngine );
-	buildDnn( cnn, outputSize );
+	CDnn dnn( rand, *mathEngine );
+	buildDnn( dnn, outputSize );
 
-	CDistributedTraining distributed( cnn, 0 );
+	CDistributedTraining distributed( dnn, 0 );
 	GTEST_LOG_( INFO ) << "Distributed default thread count is " << distributed.GetModelCount();
-	ASSERT_LT( 0, distributed.GetModelCount() );
-	ASSERT_EQ( GetAvailableCpuCores(), distributed.GetModelCount() );
+	EXPECT_LT( 0, distributed.GetModelCount() );
+	EXPECT_EQ( GetAvailableCpuCores(), distributed.GetModelCount() );
 }

--- a/NeoML/test/src/DnnDistributedTest.cpp
+++ b/NeoML/test/src/DnnDistributedTest.cpp
@@ -241,12 +241,6 @@ TEST( CDnnDistributedTest, DnnDistributedAutoThreadCountTest )
 
 TEST( CDnnDistributedTest, DnnDistributedInferenceArchived )
 {
-	IMathEngine& mathEngine = MathEngine();
-	if( mathEngine.GetType() != MET_Cpu ) {
-		GTEST_LOG_( INFO ) << "Skipped for mathEngine type != MET_Cpu";
-		return;
-	}
-
 	CString archiveName = "distributed";
 	CCustomDataset dataset( inputSize, outputSize );
 
@@ -267,7 +261,7 @@ TEST( CDnnDistributedTest, DnnDistributedInferenceArchived )
 		{
 			CArchiveFile out( archiveName + ".out", CArchive::load, GetPlatformEnv() );
 			CArchive archive( &out, CArchive::load );
-			SerializeBlob( mathEngine, archive, expected );
+			SerializeBlob( MathEngine(), archive, expected );
 		}
 		EXPECT_TRUE( CompareBlobs( *blob, *expected ) );
 	}
@@ -296,7 +290,7 @@ TEST( CDnnDistributedTest, DnnDistributedInferenceArchived )
 	{ // Check archive constructor
 		CArchiveFile file( archiveName, CArchive::load, GetPlatformEnv() );
 		CArchive archive( &file, CArchive::load );
-		CDistributedInference distributed( mathEngine, archive, /*count*/4, /*seed*/42 );
+		CDistributedInference distributed( archive, /*count*/4, /*seed*/42 );
 		EXPECT_EQ( 4, distributed.GetModelCount() );
 
 		distributed.RunOnce( dataset );

--- a/NeoML/test/src/ReferenceDnnTest.cpp
+++ b/NeoML/test/src/ReferenceDnnTest.cpp
@@ -71,6 +71,8 @@ static void getTestDnns( CPointerArray<CDnn>& dnns, CArray<CRandom>& randoms, bo
 		sourceLayers[i] = CheckCast<CSourceLayer>( dnns[i]->GetLayer( "in" ).Ptr() );
 		CPtr<CDnnBlob> blob = CDnnBlob::CreateTensor( MathEngine(), CT_Float, { 1, 1, 1, 8, 20, 30, 10 } );
 		sourceLayers[i]->SetBlob( blob );
+
+		dnns[i]->RunOnce(); // reshaped
 	}
 
 	for( int i = 0; i < numOfThreads; ++i ) {

--- a/NeoMathEngine/src/CPU/CpuMathEngineDnnDistributed.cpp
+++ b/NeoMathEngine/src/CPU/CpuMathEngineDnnDistributed.cpp
@@ -1,4 +1,5 @@
-/* Copyright © 2017-2023 ABBYY
+/* Copyright © 2017-2024 ABBYY
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/NeoMathEngine/src/CPU/CpuMathEngineDnnDistributed.h
+++ b/NeoMathEngine/src/CPU/CpuMathEngineDnnDistributed.h
@@ -1,4 +1,5 @@
-/* Copyright © 2017-2023 ABBYY
+/* Copyright © 2017-2024 ABBYY
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -21,12 +22,14 @@ limitations under the License.
 
 namespace NeoML {
 
-class CMultiThreadDistributedCommunicator {
+class CMultiThreadDistributedCommunicator final {
 public:
 	explicit CMultiThreadDistributedCommunicator( int n_threads );
+
 	void AllReduce( const CFloatHandle& handle, int size );
 	void Broadcast( const CFloatHandle& handle, int size, int root );
 	void Abort() { isAbort.store(true, std::memory_order_release); }
+
 private:
 	std::vector<float*> handles;
 


### PR DESCRIPTION
The class `CDistributedInference` implements neural network inference across multiple CPU threads simultaneously.
The number of copies of the passed neural network will equal the number of inference threads.
During network inference, each copy will not store its own set of trained layer parameters.
Instead, they will share common trained layer parameters among themselves,
thereby reducing memory consumption during inference.