### PR TITLE
[NeoML] Reference DNN with composites fix

### DIFF
--- a/NeoML/include/NeoML/Dnn/Dnn.h
+++ b/NeoML/include/NeoML/Dnn/Dnn.h
@@ -574,7 +574,7 @@ public:
 	// The method may be useful for controlling the rebuild frequency
 	bool IsRebuildRequested() const { return isRebuildNeeded; }
 	// Shares its weights with other reference dnns
-	bool IsReferenceDnn() const { return !referenceDnnInfo.IsNull(); }
+	bool IsReferenceDnn() const { return ( getOwnerDnn().referenceDnnInfo != nullptr ); }
 
 	// Gets a reference to the random numbers generator
 	CRandom& Random() { return random; }
@@ -662,6 +662,8 @@ private:
 	void reshape();
 	void rebuild();
 	size_t getOutputBlobsSize() const;
+	const CDnn& getOwnerDnn() const
+		{ return ( owner == nullptr || owner->GetDnn() == nullptr ) ? *this : owner->GetDnn()->getOwnerDnn(); }
 
 	friend class CBaseLayer;
 	friend class CCompositeLayer;

--- a/NeoML/include/NeoML/Dnn/Dnn.h
+++ b/NeoML/include/NeoML/Dnn/Dnn.h
@@ -317,11 +317,9 @@ protected:
 
 private:
 	// Describes an input connection
-	struct CInputInfo {
+	struct CInputInfo final {
 		CString Name; // the name of the layer that is connected to the input
-		int OutputNumber; // the number of that layer's output that is connected to the input
-	
-		CInputInfo() { OutputNumber = NotFound; }
+		int OutputNumber = NotFound; // the number of that layer's output that is connected to the input
 	};
 
 	IMathEngine& mathEngine; 	// the layer's MathEngine
@@ -331,7 +329,6 @@ private:
 
 	// Indicates if the layer may be trained
 	const bool isLearnable;
-
 	// Indicates if learning is enabled for the layer
 	bool isLearningEnabled;
 	// The base learning rate (may vary inside the network depending on the learning strategy)
@@ -339,6 +336,7 @@ private:
 	// Base regularization multiplier (may vary inside the network depending on the learning strategy)
 	float baseL2RegularizationMult;
 	float baseL1RegularizationMult;
+
 	// Indicates if backpropagation should be performed for the layer
 	enum TBackwardStatus {
 		BS_Unknown,
@@ -387,7 +385,6 @@ private:
 
 	// The number of graphs with which the layer is connected
 	int graphCount;
-
 	// Use timer to calculate run once time and hit count
 	bool useTimer;
 	// The total number of RunOnce calls since last Reshape
@@ -396,24 +393,20 @@ private:
 	IPerformanceCounters::CCounter::TCounterType runOnceTime;
 	// Indicates if the layer performs in-place processing (after the Reshape method call)
 	bool isInPlace;
+	// Fields used for memory optimization during training
+	int allocatedBlobs; // the mask of currently allocated blobs
+	int blobsNeededForBackward; // the mask of blobs needed for backward and learn
 
 	// Set the 'dist' layer's paramBlobs to point to the data of this layer's paramBlobs
 	void transferParamsBlob(CBaseLayer& dist) const;
-
 	// Switches the specified blobs into sequence processing mode
 	void switchBlobsToSequentialMode(CObjectArray<CDnnBlob>& blobs, TBlobCacheType cacheType, bool storeParent);
 	void switchBlobsToNonSequentialMode(CObjectArray<CDnnBlob>& blobs, TBlobCacheType cacheType, bool clear);
 	void clearAllRuntimeBlobs();
-
 	// Clones a blob to store diffs
 	CDnnBlob* cloneBlobForDiff(const CBlobDesc& desc);
-
 	// Indicates if the layer is composite (contains another sub-network)
 	virtual bool isComposite() const { return false; }
-
-	// Fields used for memory optimization during training
-	int allocatedBlobs; // the mask of currently allocated blobs
-	int blobsNeededForBackward; // the mask of blobs needed for backward and learn
 	// Sets the mask of allocated blobs
 	// If some some blobs are not marked as allocated, they will be freed during this call
 	void setAllocatedBlobs( int newMask );
@@ -433,9 +426,6 @@ private:
 	void recheckBackwardNeeded();
 	void backwardRunAndLearnOnce();
 	void transferDiffBlob( CDnnBlob* diffBlob, int outputNum );
-
-	// Indicates if the layer may be used for in-place processing (the output blobs replace the input blobs)
-	bool isInPlaceProcessAvailable() const;
 
 	friend class CDnn;
 	friend class CDnnLayerGraph;

--- a/NeoML/include/NeoML/Dnn/Dnn.h
+++ b/NeoML/include/NeoML/Dnn/Dnn.h
@@ -241,6 +241,8 @@ protected:
 	bool IsBackwardPerformed() const;
 	// Indicates that backpropagation must be performed for the layer when Learn method is called
 	bool IsBackwardNeeded() const;
+	// Layer may contain empty paramBlob of given index
+	virtual bool ContainsEmptyParamBlob( int ) const { return false; }
 	// Gets a pointer to the layer connected to the given input
 	CBaseLayer* GetInputLayer(int input) { return inputLinks[input].Layer; }
 	const CBaseLayer* GetInputLayer(int input) const { return inputLinks[input].Layer; }

--- a/NeoML/include/NeoML/Dnn/Dnn.h
+++ b/NeoML/include/NeoML/Dnn/Dnn.h
@@ -739,6 +739,8 @@ private:
 	void serialize( CArchive& archive, bool optimizeDnn );
 	// Thread-safe coping the state (with no copy paramBlobs the pointers used) of a dnn to a new dnn
 	void initializeReferenceDnn( CDnn& dnn, CDnn& newDnn, TPtrOwnerReferenceDnnInfo&& info );
+	// Update layers' settings for a better paramBlobs sharing
+	static void allowLayersToShareParamBlobs( CDnn& dnn );
 };
 
 } // namespace NeoML

--- a/NeoML/include/NeoML/Dnn/DnnDistributed.h
+++ b/NeoML/include/NeoML/Dnn/DnnDistributed.h
@@ -137,10 +137,10 @@ public:
 	CDistributedInference( CArchive& archive, int threadsCount, int seed = 42,
 		bool optimizeDnn = true, size_t memoryLimit = 0 );
 
-	virtual ~CDistributedInference() = default;
+	virtual ~CDistributedInference();
 
 	// Gets the created models number
-	int GetModelCount() const { return threadParams.Refs.Size(); }
+	int GetModelCount() const { return threadPool->Size(); }
 	// Runs the inference for all of the networks
 	// NOTE: Main thread waits while all tasks are done
 	void RunOnce( IDistributedDataset& data );
@@ -152,12 +152,7 @@ public:
 
 private:
 	// Params to transfer to all threads function
-	struct CThreadParams final {
-		IDistributedDataset* Data = nullptr; // Pointer to data for the inference for all dnns
-		CObjectArray<CDnnReference> Refs; // Separate dnn for each thread
-		CArray<CString> ErrorMessages; // Containers for errors if it happened
-		bool IsErrorHappened = false;
-	};
+	struct CThreadParams;
 
 	// The operator of worker threads
 	CPtrOwner<IThreadPool> threadPool;
@@ -166,9 +161,7 @@ private:
 	// Class to create reference dnns
 	CPtr<CReferenceDnnFactory> referenceDnnFactory;
 	// Each `RunOnce` task parameters
-	CThreadParams threadParams;
-
-	void initialize( int threadsCount );
+	CPtrOwner<CThreadParams> threadParams;
 };
 
 } // namespace NeoML

--- a/NeoML/include/NeoML/Dnn/Layers/ChannelwiseWith1x1Layer.h
+++ b/NeoML/include/NeoML/Dnn/Layers/ChannelwiseWith1x1Layer.h
@@ -1,4 +1,4 @@
-/* Copyright © 2017-2023 ABBYY
+/* Copyright © 2017-2024 ABBYY
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -57,6 +57,9 @@ protected:
 	void Reshape() override;
 	void RunOnce() override;
 	void BackwardOnce() override { NeoAssert( false ); }
+	// Specialization for transferParamsBlob
+	bool ContainsEmptyParamBlob( int i ) const override
+		{ return paramBlobs[i] == nullptr && ( i == P_ChannelwiseFreeTerm || i == P_ConvFreeTerm ); }
 
 private:
 	// paramBlobs indices
@@ -69,14 +72,14 @@ private:
 		P_Count
 	};
 
-	void recreateConvDesc();
-	void recreateRowwiseDesc();
-
 	int stride; // stride of channnelwise convolution
 	CActivationDesc activation; // activation after channelwise convolution
 	bool residual; // Does block have residual connection?
 	CChannelwiseConvolutionDesc* convDesc = nullptr; // descriptor of channelwise convolution
 	CRowwiseOperationDesc* rowwiseDesc = nullptr; // matrix multiplication optimization
+
+	void recreateConvDesc();
+	void recreateRowwiseDesc();
 };
 
 } // namespace NeoML

--- a/NeoML/include/NeoML/Dnn/Layers/MobileNetV2BlockLayer.h
+++ b/NeoML/include/NeoML/Dnn/Layers/MobileNetV2BlockLayer.h
@@ -1,4 +1,4 @@
-/* Copyright © 2017-2023 ABBYY
+/* Copyright © 2017-2024 ABBYY
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -74,6 +74,9 @@ protected:
 	void Reshape() override;
 	void RunOnce() override;
 	void BackwardOnce() override { NeoAssert( false ); }
+	// Specialization for transferParamsBlob
+	bool ContainsEmptyParamBlob( int i ) const override
+		{ return !paramBlobs[i] && ( i == P_ChannelwiseFreeTerm || i == P_DownFreeTerm || i == P_ExpandFreeTerm ); }
 
 private:
 	// paramBlobs indices

--- a/NeoML/include/NeoML/Dnn/Layers/MobileNetV3BlockLayer.h
+++ b/NeoML/include/NeoML/Dnn/Layers/MobileNetV3BlockLayer.h
@@ -1,4 +1,4 @@
-/* Copyright © 2017-2023 ABBYY
+/* Copyright © 2017-2024 ABBYY
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -58,6 +58,9 @@ private:
 	void Reshape() override;
 	void RunOnce() override;
 	void BackwardOnce() override { NeoAssert( false ); }
+	// Specialization for transferParamsBlob
+	bool ContainsEmptyParamBlob( int i ) const override
+		{ return paramBlobs[i] == nullptr && ( i == P_ChannelwiseFreeTerm || i == P_ExpandFreeTerm ); }
 
 private:
 	// paramBlobs indices
@@ -111,6 +114,9 @@ protected:
 	void Reshape() override;
 	void RunOnce() override;
 	void BackwardOnce() override { NeoAssert( false ); }
+	// Specialization for transferParamsBlob
+	bool ContainsEmptyParamBlob( int i ) const override
+		{ return paramBlobs[i] == nullptr && ( i == P_DownFreeTerm ); }
 
 private:
 	// paramBlobs indices

--- a/NeoML/src/Dnn/BaseLayer.cpp
+++ b/NeoML/src/Dnn/BaseLayer.cpp
@@ -320,6 +320,10 @@ void CBaseLayer::transferParamsBlob( CBaseLayer& dist ) const
 		// Create reference copy of dist.paramBlobs with shared buffer
 		// Takes a pointer to parent's blob to access memory
 		for( int j = 0; j < dist.paramBlobs.Size(); ++j ) {
+			if( ContainsEmptyParamBlob( j ) ) {
+				dist.paramBlobs[j] = nullptr; // may contain empty parameter
+				continue;
+			}
 			NeoAssertMsg( paramBlobs[j] != nullptr, "transferParamsBlob: All trainable paramBlobs should exist" );
 			dist.paramBlobs[j] = CDnnBlob::CreateWindowBlob( paramBlobs[j], paramBlobs[j]->GetDesc().BatchLength() );
 		}

--- a/NeoML/src/Dnn/Dnn.cpp
+++ b/NeoML/src/Dnn/Dnn.cpp
@@ -499,7 +499,10 @@ CPtr<const CBaseLayer> CDnn::GetLayer(const CArray<CString>& path) const
 
 void CDnn::AddLayerImpl( CBaseLayer& layer )
 {
-	NeoAssertMsg( !IsReferenceDnn(), "For ReferenceDnn adding layers is restricted" );
+	NeoAssertMsg( !IsReferenceDnn()
+		|| dynamic_cast<CCompositeSourceLayer*>( &layer ) != nullptr
+		|| dynamic_cast<CCompositeSinkLayer*>( &layer ) != nullptr,
+		"For ReferenceDnn adding layers is restricted" );
 	layer.CheckLayerArchitecture( !layerMap.Has( layer.GetName() ), "layer already in this dnn" );
 	layer.CheckLayerArchitecture( layer.GetDnn() == 0, "layer already added to other dnn" );
 
@@ -523,7 +526,10 @@ void CDnn::ForceRebuild()
 
 void CDnn::DeleteLayerImpl( CBaseLayer& layer )
 {
-	NeoAssertMsg( !IsReferenceDnn(), "For ReferenceDnn deleting layers is restricted" );
+	NeoAssertMsg( !IsReferenceDnn()
+		|| dynamic_cast<CCompositeSourceLayer*>( &layer ) != nullptr
+		|| dynamic_cast<CCompositeSinkLayer*>( &layer ) != nullptr,
+		"For ReferenceDnn deleting layers is restricted" );
 	layer.CheckLayerArchitecture( HasLayer( layer.GetName() ), "deletion of the layer which is not in this dnn" );
 
 	// Set the flag that indicates the network should be rebuilt (configuration has changed)

--- a/NeoML/src/Dnn/Layers/CompositeLayer.cpp
+++ b/NeoML/src/Dnn/Layers/CompositeLayer.cpp
@@ -482,7 +482,7 @@ void CCompositeLayer::SetInternalDnnParams()
 	internalDnn->SetLogFrequency(GetDnn()->GetLogFrequency());
 	internalDnn->RequestReshape(forcedReshape);
 	// Switch learning on or off
-	if(IsLearningEnabled()) {
+	if( GetDnn()->IsLearningEnabled() ) {
 		internalDnn->EnableLearning();
 	} else {
 		internalDnn->DisableLearning();

--- a/NeoML/src/Dnn/Optimization/Graph.cpp
+++ b/NeoML/src/Dnn/Optimization/Graph.cpp
@@ -269,6 +269,9 @@ void CGraph::SwitchOutputs( CBaseLayer& oldOutputLayer, int oldOutputIndex,
 	NeoAssert( oldLayerPos != NotFound );
 	NeoAssert( graphLinks.GetNextPosition( &oldOutputLayer, oldLayerPos ) == NotFound );
 	CLayerLinks& oldLayerLinks = graphLinks.GetValue( oldLayerPos );
+	if ( oldOutputIndex >= oldLayerLinks.Outputs.Size() ) {
+		return; // Sink has no connection
+	}
 	NeoAssert( oldOutputIndex < oldLayerLinks.Outputs.Size() );
 
 	// Making local copy of inputs because of graph modifications during Disconnect/Connect calls

--- a/NeoML/src/Dnn/ReferenceDnnFactory.cpp
+++ b/NeoML/src/Dnn/ReferenceDnnFactory.cpp
@@ -165,6 +165,7 @@ void CReferenceDnnFactory::initializeReferenceDnn( CDnn& dnn, CDnn& newDnn, TPtr
 			SerializeLayer( archive, dnn.mathEngine, copyLayer );
 			layer->transferParamsBlob( *copyLayer );
 		}
+		copyLayer->DisableLearning();
 		newDnn.AddLayer( *copyLayer );
 	}
 

--- a/NeoML/src/Dnn/ReferenceDnnFactory.cpp
+++ b/NeoML/src/Dnn/ReferenceDnnFactory.cpp
@@ -119,7 +119,6 @@ void CReferenceDnnFactory::serialize( CArchive& archive, bool optimizeDnn )
 
 	NeoAssert( archive.IsLoading() );
 	Origin->Dnn.Serialize( archive );
-	archive.Close();
 
 	NeoAssert( !Origin->Dnn.IsReferenceDnn() );
 	if( optimizeDnn ) {

--- a/NeoML/src/Dnn/ReferenceDnnFactory.cpp
+++ b/NeoML/src/Dnn/ReferenceDnnFactory.cpp
@@ -70,6 +70,10 @@ CReferenceDnnFactory::CReferenceDnnFactory( CDnn&& dnn, bool optimizeDnn ) :
 	NeoAssert( !dnn.IsReferenceDnn() );
 	NeoAssert( Origin->Dnn.IsReferenceDnn() );
 
+	if( optimizeDnn ) {
+		( void ) OptimizeDnn( dnn );
+	}
+
 	// Temporal convert an ordinary dnn to a reference dnn
 	// by capturing non-empty referenceDnnInfo from the original dnn
 	swap( dnn.referenceDnnInfo, Origin->Dnn.referenceDnnInfo );
@@ -77,9 +81,6 @@ CReferenceDnnFactory::CReferenceDnnFactory( CDnn&& dnn, bool optimizeDnn ) :
 
 	// Copy state with moving of the paramBlobs
 	initializeReferenceDnn( dnn, Origin->Dnn, TPtrOwnerReferenceDnnInfo{} );
-	if( optimizeDnn == true ) {
-		( void ) OptimizeDnn( Origin->Dnn );
-	}
 	// The original dnn still has empty referenceDnnInfo
 
 	// Convert everything back
@@ -120,7 +121,8 @@ void CReferenceDnnFactory::serialize( CArchive& archive, bool optimizeDnn )
 	Origin->Dnn.Serialize( archive );
 	archive.Close();
 
-	if( optimizeDnn == true ) {
+	NeoAssert( !Origin->Dnn.IsReferenceDnn() );
+	if( optimizeDnn ) {
 		( void ) OptimizeDnn( Origin->Dnn );
 	}
 

--- a/NeoML/test/src/ReferenceDnnTest.cpp
+++ b/NeoML/test/src/ReferenceDnnTest.cpp
@@ -148,14 +148,18 @@ static void runDnn( int thread, void* arg )
 	}
 }
 
-static void createDnn( CDnn& dnn, bool learn = false, float dropoutRate = 0.1f )
+static void createDnn( CDnn& dnn, bool learn = false, bool composite = false, float dropoutRate = 0.1f )
 {
 	CBaseLayer* layer = Source( dnn, "in" );
-	layer = FullyConnected( 50, true )( "fc1", layer );
-	layer = Dropout( dropoutRate )( "dp1", layer );
-	layer = FullyConnected( 200 )( "fc2", layer );
-	layer = Dropout( dropoutRate )( "dp2", layer );
-	layer = FullyConnected( 10 )( "fc3", layer );
+	if( composite ) {
+		layer = TransformerEncoder( 2, 8, dropoutRate, 10, TActivationFunction::AF_ReLU )( "te", layer );
+	} else {
+		layer = FullyConnected( 50, true )( "fc1", layer );
+		layer = Dropout( dropoutRate )( "dp1", layer );
+		layer = FullyConnected( 200 )( "fc2", layer );
+		layer = Dropout( dropoutRate )( "dp2", layer );
+		layer = FullyConnected( 10 )( "fc3", layer );
+	}
 	( void ) Sink( layer, "sink" );
 
 	if( learn ) {
@@ -337,16 +341,18 @@ static void perfomanceTest( IMathEngine& mathEngine, bool useReference, bool lea
 }
 
 // Scenario: learn dnn, then use multi-threaded inference, each thread creates reference dnn by itself
-static void implTest( IMathEngine& mathEngine, bool useReference, bool learn = true, int numOfThreads = 4 )
+static void implTest( IMathEngine& mathEngine, bool useReference, bool learn = true, int numOfThreads = 4,
+	bool composite = false )
 {
 	// 1. Create and learn dnn
 	CRandom random( 0x123 );
-	CPtr<CDnnBlob> blob = getInitedBlob( mathEngine, random, { 1, 1, 1, 8, 20, 30, 100 } );
-	CPtr<CDnnBlob> labelBlob = getInitedBlob( mathEngine, random, { 1, 1, 1, 1, 1, 1, 10 } );
+	CPtr<CDnnBlob> blob = getInitedBlob( mathEngine, random,
+		{ 1, 1, 1, (composite ? 1 : 8), (composite ? 1 : 20), (composite ? 1 : 30), 100 } );
+	CPtr<CDnnBlob> labelBlob = getInitedBlob( mathEngine, random, { 1, 1, 1, 1, 1, 1, (composite ? 100 : 10) } );
 
 	CPtr<CDnnReference> dnnRef = new CDnnReferenceTest( random, mathEngine );
 	CDnn& dnn = dnnRef->Dnn;
-	createDnn( dnn, learn );
+	createDnn( dnn, learn, composite );
 	setInputDnn( dnn, *blob, ( learn ? labelBlob.Ptr() : nullptr ), /*reshape*/true );
 	if( learn ) {
 		learnDnn( dnn );
@@ -400,6 +406,16 @@ TEST( ReferenceDnnTest, CReferenceDnnFactoryTest )
 	implTest( *mathEngine, /*useReference*/true );
 
 	implTest( *mathEngine, /*useReference*/false );
+}
+
+TEST( ReferenceDnnTest, CReferenceDnnFactoryCompositeTest )
+{
+	// As mathEngine is owned, there are no buffers in pools left for any thread
+	CPtrOwner<IMathEngine> mathEngine( CreateCpuMathEngine( /*memoryLimit*/0u ) );
+
+	implTest( *mathEngine, /*useReference*/true, /*learn*/true, /*numOfThreads*/5, /*composite*/true );
+
+	implTest( *mathEngine, /*useReference*/false, /*learn*/true, /*numOfThreads*/5, /*composite*/true );
 }
 
 TEST( ReferenceDnnTest, InferenceReferenceDnns )


### PR DESCRIPTION
ChangeList:

1. `CCompositeLayer` - forwarded `isReferenceDnn` and `isLearningEnabled` flags to the internal dnn
2. `CMultiheadAttentionLayer` may have non-connected output, allow it in optimization 
3. `CMultichannelLookupLayer` - apply `SetUseFrameworkLearning( true )` for share the state
4. `CDistributedInference` - avoid assert calls on some empty results 
5. Channelwise-layers may contain empty paramBLobs
6. `ReferenceDnnFactory` does not close an archive
7. Update reference dnn tests to check for composite layers