### PR TITLE
[CCudaMathEngine] Avoid races in MatrixSpreadRowsKernel

### DIFF
--- a/NeoMathEngine/src/GPU/CUDA/Kernels/CudaBlasKernels.h
+++ b/NeoMathEngine/src/GPU/CUDA/Kernels/CudaBlasKernels.h
@@ -1103,7 +1103,8 @@ __global__ void MatrixSpreadRowsKernel(const T* __restrict__ source, int height,
 	source += j * width + i;
 	result += indices[j] * width + i;
 	for(int c = 0; c < count; ++c) {
-		*result = *source;
+		// In CGatherLayer the indices may contain repeated values, what can lead to races
+		atomicAdd(result, *source);
 		source += step;
 		result += step;
 	}


### PR DESCRIPTION
In `CGatherLayer::BackwardOnce()` method `mathEngine.MatrixSpreadRows( vectors, h, w, result, rh, shiftedIndices, v );` was called with `shiftedIndices` that may contain repeated value. It lead to race condition in `result` items summation.