### PR TITLE
[NeoML] IShuffledBatchGenerator in CProblemSourceLayer

### DIFF
--- a/NeoML/include/NeoML/Dnn/Layers/FullyConnectedSourceLayer.h
+++ b/NeoML/include/NeoML/Dnn/Layers/FullyConnectedSourceLayer.h
@@ -1,4 +1,4 @@
-/* Copyright © 2017-2020 ABBYY Production LLC
+/* Copyright © 2017-2024 ABBYY
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -78,7 +78,9 @@ private:
 	bool isBatchLoaded( int index ) const;
 };
 
-NEOML_API CLayerWrapper<CFullyConnectedSourceLayer> FullyConnectedSource(
-	TBlobType labelType, int batchSize, int maxBatchCount, IProblem* problem );
+// Creates CFullyConnectedSourceLayer with the name
+NEOML_API CFullyConnectedSourceLayer* FullyConnectedSource( CDnn& dnn, const char* name,
+	TBlobType labelType, int batchSize, int maxBatchCount, IProblem* problem,
+	int numberOfElements = 1, bool isZeroFreeTerm = false );
 
 } // namespace NeoML

--- a/NeoML/include/NeoML/Dnn/Layers/ModelWrapperLayer.h
+++ b/NeoML/include/NeoML/Dnn/Layers/ModelWrapperLayer.h
@@ -80,7 +80,7 @@ class NEOML_API CDnnModelWrapper : public IModel {
 public:
 	explicit CDnnModelWrapper(IMathEngine& mathEngine, unsigned int seed = 0xDEADFACE);
 
-	int GetClassCount() const override;
+	int GetClassCount() const override { return ClassCount; }
 	bool Classify(const CFloatVectorDesc& data, CClassificationResult& result) const override;
 	void Serialize(CArchive& archive) override;
 

--- a/NeoML/include/NeoML/Dnn/Layers/ModelWrapperLayer.h
+++ b/NeoML/include/NeoML/Dnn/Layers/ModelWrapperLayer.h
@@ -66,7 +66,11 @@ private:
 	int nextProblemIndex = NotFound; // the index of the next element in the problem to be passed
 	TBlobType labelType = CT_Float; // the data type for labels
 	CPtr<const IProblem> problem; // the classification problem the network is solving
-	CArray<float> exchangeBufs[3]{};
+
+	enum { EB_Data, EB_Label, EB_Weight, EB_Count_ };
+	CArray<float> exchangeBufs[EB_Count_]{};
+
+	void fillExchangeBuffers( int shift );
 };
 
 // Creates CProblemSourceLayer with the name

--- a/NeoML/include/NeoML/TraditionalML/Shuffler.h
+++ b/NeoML/include/NeoML/TraditionalML/Shuffler.h
@@ -1,4 +1,4 @@
-/* Copyright © 2017-2020 ABBYY Production LLC
+/* Copyright © 2017-2024 ABBYY
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ namespace NeoML {
 // The shuffler class
 // Uses the standard shuffling algorithm, not all at once but sequentially; as a result, the first N positions are only shuffled among themselves
 // For example, you can use it to get the random indices in an array
-class NEOML_API CShuffler {
+class NEOML_API CShuffler final {
 public:
 	CShuffler( CRandom& _random, int count );
 
@@ -34,6 +34,10 @@ public:
 	int SetNext( int index );
 	// Finishes shuffling and returns all indices
 	const CArray<int>& GetAllIndices();
+	// Is shuffling finished
+	bool IsFinished() const { return nextIndex == indices.Size(); }
+	// Reset state to use shuffler again for the same array
+	void Reset() { nextIndex = 0; }
 
 private:
 	CRandom& random;

--- a/NeoML/src/Dnn/Layers/FullyConnectedSourceLayer.cpp
+++ b/NeoML/src/Dnn/Layers/FullyConnectedSourceLayer.cpp
@@ -1,4 +1,4 @@
-/* Copyright © 2017-2020 ABBYY Production LLC
+/* Copyright © 2017-2024 ABBYY
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -310,15 +310,20 @@ bool CFullyConnectedSourceLayer::isBatchLoaded( int index ) const
 	return ( batchFirstLoadedIndex <= index && index <= batchLastLoadedIndex );
 }
 
-CLayerWrapper<CFullyConnectedSourceLayer> FullyConnectedSource( TBlobType labelType,
-	int batchSize, int maxBatchCount, IProblem* problem )
+// Creates CFullyConnectedSourceLayer with the name
+CFullyConnectedSourceLayer* FullyConnectedSource( CDnn& dnn, const char* name,
+	TBlobType labelType, int batchSize, int maxBatchCount, IProblem* problem, int numberOfElements, bool isZeroFreeTerm )
 {
-	return CLayerWrapper<CFullyConnectedSourceLayer>( "FullyConnectedSource", [=, &problem]( CFullyConnectedSourceLayer* result ) {
-		result->SetLabelType( labelType );
-		result->SetBatchSize( batchSize );
-		result->SetMaxBatchCount( maxBatchCount );
-		result->SetProblem( problem );
-	} );
+	CPtr<CFullyConnectedSourceLayer> result = new CFullyConnectedSourceLayer( dnn.GetMathEngine() );
+	result->SetLabelType( labelType );
+	result->SetBatchSize( batchSize );
+	result->SetMaxBatchCount( maxBatchCount );
+	result->SetProblem( problem );
+	result->SetNumberOfElements( numberOfElements );
+	result->SetZeroFreeTerm( isZeroFreeTerm );
+	result->SetName( name );
+	dnn.AddLayer( *result );
+	return result;
 }
 
 } // namespace NeoML

--- a/NeoML/src/TraditionalML/Shuffler.cpp
+++ b/NeoML/src/TraditionalML/Shuffler.cpp
@@ -1,4 +1,4 @@
-/* Copyright © 2017-2020 ABBYY Production LLC
+/* Copyright © 2017-2024 ABBYY
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,9 +20,11 @@ limitations under the License.
 
 namespace NeoML {
 
-CShuffler::CShuffler( CRandom& _random, int count )
-	: random( _random ), nextIndex( 0 )
+CShuffler::CShuffler( CRandom& _random, int count ) :
+	random( _random ),
+	nextIndex( 0 )
 {
+	NeoAssert( count > 1 );
 	indices.SetSize( count );
 	for( int i = 0; i < indices.Size(); ++i ) {
 		indices[i] = i;
@@ -32,19 +34,15 @@ CShuffler::CShuffler( CRandom& _random, int count )
 inline int CShuffler::getSwapIndex( int swapIndex )
 {
 	if( swapIndex != nextIndex ) {
-		int tmp = indices[swapIndex];
-		indices[swapIndex] = indices[nextIndex];
-		indices[nextIndex] = tmp;
+		FObj::swap( indices[swapIndex], indices[nextIndex] );
 	}
-
 	return indices[nextIndex++];
 }
 
 int CShuffler::Next()
 {
 	NeoPresume( nextIndex < indices.Size() );
-
-	int swapIndex = random.UniformInt( nextIndex, indices.Size() - 1 );
+	const int swapIndex = random.UniformInt( nextIndex, indices.Size() - 1 );
 	return getSwapIndex( swapIndex );
 }
 
@@ -64,7 +62,6 @@ int CShuffler::SetNext( int index )
 		}
 		NeoAssert( swapIndex != NotFound );
 	}
-
 	return getSwapIndex( swapIndex );
 }
 
@@ -73,8 +70,7 @@ const CArray<int>& CShuffler::GetAllIndices()
 	while( nextIndex < indices.Size() ) {
 		Next();
 	}
-
 	return indices;
 }
 
-}
+} // namespace NeoML

--- a/NeoML/test/src/CMakeLists.txt
+++ b/NeoML/test/src/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(${PROJECT_NAME} INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/OptimizerFunctionsTest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ParameterLayerTest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/PCATest.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ProblemSourceLayerTest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RandomProblem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RandomProblem.h
     ${CMAKE_CURRENT_SOURCE_DIR}/ReferenceDnnTest.cpp

--- a/NeoML/test/src/ProblemSourceLayerTest.cpp
+++ b/NeoML/test/src/ProblemSourceLayerTest.cpp
@@ -1,0 +1,127 @@
+﻿/* Copyright © 2024 ABBYY
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--------------------------------------------------------------------------------------------------------------*/
+
+#include <common.h>
+#pragma hdrstop
+
+#include <TestFixture.h>
+
+using namespace NeoML;
+using namespace NeoMLTest;
+
+namespace NeoMLTest {
+
+template<class T>
+static void recreateLayer( IMathEngine& mathEngine, CPtr<T>& layer,
+	const char* name, int batchSize, TBlobType type, CMemoryProblem* problem, CDnn& dnn )
+{
+	layer->SetName( name );
+	layer->SetBatchSize( batchSize );
+
+	CMemoryFile file;
+	CArchive archive( &file, CArchive::SD_Storing );
+	layer->Serialize( archive );
+	archive.Close();
+	layer = new T( mathEngine );
+	file.SeekToBegin();
+	archive.Open( &file, CArchive::SD_Loading );
+	layer->Serialize( archive );
+
+	EXPECT_EQ( type, layer->GetLabelType() );
+	layer->SetProblem( problem );
+	dnn.AddLayer( *layer );
+}
+
+// Check for float labels == enumBinarization(int labels).
+// As a type T could be CFullyConnectedSourceLayer or CProblemSourceLayer.
+template<class T>
+static void testLabelTypes( CDnn& dnn, CPtr<T> intLayer, CPtr<T> floatLayer )
+{
+	const int featureCount = 5;
+	const int vectorCount = 10;
+	const int classCount = 3;
+	const int runCount = 10;
+	const int batchSize = ( vectorCount / 2 ) - 1;
+
+	static_assert( vectorCount >= classCount, "" );
+	static_assert( classCount > 2, "" );
+
+	CPtr<CMemoryProblem> problem = new CMemoryProblem( featureCount, classCount );
+	for( int i = 0; i < vectorCount; ++i ) {
+		CSparseFloatVector vector;
+		const int index = dnn.Random().UniformInt( 0, featureCount - 1 );
+		vector.SetAt( index, 1.f );
+		problem->Add( vector, i % classCount );
+	}
+
+	intLayer->SetLabelType( CT_Int );
+	recreateLayer( dnn.GetMathEngine(), intLayer, "intLayer", batchSize, CT_Int, problem.Ptr(), dnn );
+	recreateLayer( dnn.GetMathEngine(), floatLayer, "floatLayer", batchSize, CT_Float, problem.Ptr(), dnn );
+
+	CPtr<CEnumBinarizationLayer> enumBin = EnumBinarization( classCount )( CDnnLayerLink( intLayer.Ptr(), 1 ) );
+
+	Sink( CDnnLayerLink( floatLayer.Ptr(), 0 ), "floatData" );
+	CPtr<CSinkLayer> floatLabel = Sink( CDnnLayerLink( floatLayer.Ptr(), 1 ), "floatLabel" );
+	Sink( CDnnLayerLink( floatLayer.Ptr(), 2 ), "floatWeights" );
+
+	Sink( CDnnLayerLink( intLayer.Ptr(), 0 ), "intData" );
+	CPtr<CSinkLayer> intLabel = Sink( enumBin.Ptr(), "intLabel" );
+	Sink( CDnnLayerLink( intLayer.Ptr(), 2 ), "intWeights" );
+
+	for( int run = 0; run < runCount; ++run ) {
+		dnn.RunOnce();
+
+		CArray<float> expected;
+		expected.SetSize( floatLabel->GetBlob()->GetDataSize() );
+		floatLabel->GetBlob()->CopyTo( expected.GetPtr() );
+
+		CArray<float> result;
+		result.SetSize( intLabel->GetBlob()->GetDataSize() );
+		intLabel->GetBlob()->CopyTo( result.GetPtr() );
+
+		EXPECT_EQ( classCount * batchSize, expected.Size() );
+		EXPECT_EQ( expected.Size(), result.Size() );
+		for( int i = 0; i < expected.Size(); ++i ) {
+			EXPECT_FLOAT_EQ( expected[i], result[i] );
+		}
+	}
+}
+
+} // namespace NeoMLTest
+
+//---------------------------------------------------------------------------------------------------------------------
+
+TEST( CDnnProblemTest, LabelTypes )
+{
+	CRandom random( 0x0CA );
+	{
+		CDnn dnn( random, MathEngine() );
+
+		CPtr<CProblemSourceLayer> intSource = new CProblemSourceLayer( MathEngine() );
+		CPtr<CProblemSourceLayer> floatSource = new CProblemSourceLayer( MathEngine() );
+
+		testLabelTypes( dnn, intSource, floatSource );
+	}
+	{
+		CDnn dnn( random, MathEngine() );
+
+		CPtr<CFullyConnectedSourceLayer> intFc = new CFullyConnectedSourceLayer( MathEngine() );
+		intFc->SetNumberOfElements( 3 );
+		CPtr<CFullyConnectedSourceLayer> floatFc = new CFullyConnectedSourceLayer( MathEngine() );
+		floatFc->SetNumberOfElements( 3 );
+
+		testLabelTypes( dnn, intFc, floatFc );
+	}
+}


### PR DESCRIPTION
The `SetProblem` method of the `CProblemSourceLayer` class now has an optional `shuffle` flag, which when enabled causes the indexes in the batch to be randomly generated. At the same time, a new permutation is generated each epoch, meaning that duplicates in the batch are reduced to a minimum.