### PR TITLE
[NeoML] DistributedTraining uses IsDnnInferenced

### DIFF
--- a/NeoML/include/NeoML/Dnn/DnnDistributed.h
+++ b/NeoML/include/NeoML/Dnn/DnnDistributed.h
@@ -113,10 +113,12 @@ private:
 	CPointerArray<CRandom> rands;
 	// Separate dnn for each thread
 	CPointerArray<CDnn> cnns;
+	// Indicates for what dnns the inference was performed
+	CArray<bool> isDnnInferenced;
 	// Separate `batchSize` for each dnn (may be empty) in a thread
 	CArray<int> batchSize;
 	// `Train()` cannot be called if it `isFirstRun`
-	// `batchSize` may not be equal 0, if it `isFirstRun` for `RunOnce`, `RunAndBackwardOnce` or `RunAndLearnOnce`.
+	// `batchSize` may not be equal 0, if it `isFirstRun` for `RunAndBackwardOnce` or `RunAndLearnOnce`.
 	bool isFirstRun = true;
 	// Containers for errors if it happened
 	CArray<CString> errorMessages;


### PR DESCRIPTION
Previously, if you did a `RunOnce` (even on random data) before a `RunAndBackward`, it would no longer be a `firstRun` and you could send batches as you wish. So you could never learn some extra dnn. Now you can not.

All dnns must have `paramBlobs` initialized to run `solver->Train()` for all of them (at least `RunOnce` must be completed for each dnn for this to happen).

The `solver->Train()` must run for all dnns because all dnns must have the same `paramBlobs` in each epoch.