### PR TITLE
[NeoML] Update ISubwordEncoderWithCache

### DIFF
--- a/NeoML/src/TraditionalML/SubwordEncoder.cpp
+++ b/NeoML/src/TraditionalML/SubwordEncoder.cpp
@@ -104,6 +104,11 @@ bool ISubwordEncoderWithCache::CCache::Request( const CString& word,
 void ISubwordEncoderWithCache::CCache::Add( const CString& word,
 	const CArray<int>& tokenIds, const CArray<int>& tokenLengths )
 {
+	// If cache is disabled
+	if( cachePeriod == NotFound ) {
+		return;
+	}
+
 	NeoAssert( !wordCache.Has( word ) );
 	NeoAssert( tokenIds.Size() == tokenLengths.Size() );
 


### PR DESCRIPTION
`IBytePairEncoder` inherits `ISubwordEncoderWithCache` as an interface.
It seems that the `ISubwordEncoder` interface without cache is written just to be there.

Using `ISubwordEncoderWithCache` in a multi-threaded environment is only allowed with cache disabled. This only gives a small time increase. There is no need to completely rework it for multi-threading. But in the future, someone might need it.

The only edit needed to disable cache works is to disable addition to the cache.