### PR TITLE
adding cstring

### DIFF
--- a/NeoMathEngine/src/CPU/mlas/inc/mlas.h
+++ b/NeoMathEngine/src/CPU/mlas/inc/mlas.h
@@ -20,6 +20,7 @@ Abstract:
 #include <cstddef>
 #include <cstdlib>
 #include <cstdint>
+#include <cstring>
 
 //
 // Define the calling convention for Windows targets.

--- a/NeoMathEngine/src/CPU/mlas/inc/mlas_float16.h
+++ b/NeoMathEngine/src/CPU/mlas/inc/mlas_float16.h
@@ -21,6 +21,7 @@ Abstract:
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 
 
 using _mlas_fp16_ = uint16_t;


### PR DESCRIPTION
trying to build NeoML math engine on arm64 clang setup gives this:

```

/opt/conan_global/p/b/tech-af88f2c6baec9/b/src/NeoMathEngine/src/CPU/mlas/lib/halfgemm.cpp:195:5: error: no member named 'memcpy' in namespace 'std'; did you mean simply 'memcpy'?
  195 |     std::memcpy(&buf, src, len * sizeof(_mlas_fp16_));
      |     ^~~~~~~~~~~
      |     memcpy
/usr/include/string.h:43:14: note: 'memcpy' declared here
   43 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
      |              ^
1 error generated.
gmake[2]: *** [NeoMathEngine/src/CPU/mlas/CMakeFiles/onnxruntime_mlas.dir/build.make:118: NeoMathEngine/src/CPU/mlas/CMakeFiles/onnxruntime_mlas.dir/lib/halfgemm.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
/opt/conan_global/p/b/tech-af88f2c6baec9/b/src/NeoMathEngine/src/CPU/mlas/lib/halfgemm_kernel_neon.cpp:80:5: error: no member named 'memcpy' in namespace 'std'; did you mean simply 'memcpy'?
   80 |     std::memcpy(&buf, src, len * sizeof(float));
      |     ^~~~~~~~~~~
      |     memcpy
/usr/include/string.h:43:14: note: 'memcpy' declared here
   43 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
      |              ^
1 error generated.
gmake[2]: *** [NeoMathEngine/src/CPU/mlas/CMakeFiles/onnxruntime_mlas.dir/build.make:716: NeoMathEngine/src/CPU/mlas/CMakeFiles/onnxruntime_mlas.dir/lib/halfgemm_kernel_neon.cpp.o] Error 1
/opt/conan_global/p/b/tech-af88f2c6baec9/b/src/NeoMathEngine/src/CPU/mlas/lib/activate_fp16.cpp:631:13: error: no member named 'memcpy' in namespace 'std'; did you mean simply 'memcpy'?
  631 |             std::memcpy(&buf, buffer, n * sizeof(_mlas_fp16_));
      |             ^~~~~~~~~~~
      |             memcpy
/usr/include/string.h:43:14: note: 'memcpy' declared here
   43 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
      |              ^
/opt/conan_global/p/b/tech-af88f2c6baec9/b/src/NeoMathEngine/src/CPU/mlas/lib/activate_fp16.cpp:716:13: error: no member named 'memcpy' in namespace 'std'; did you mean simply 'memcpy'?
  716 |             std::memcpy(&addbuf, addsrc, n * sizeof(_mlas_fp16_));
      |             ^~~~~~~~~~~
      |             memcpy
/usr/include/string.h:43:14: note: 'memcpy' declared here
   43 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
      |              ^
/opt/conan_global/p/b/tech-af88f2c6baec9/b/src/NeoMathEngine/src/CPU/mlas/lib/activate_fp16.cpp:717:13: error: no member named 'memcpy' in namespace 'std'; did you mean simply 'memcpy'?
  717 |             std::memcpy(&buf, buffer, n * sizeof(_mlas_fp16_));
      |             ^~~~~~~~~~~
      |             memcpy
/usr/include/string.h:43:14: note: 'memcpy' declared here
   43 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
      |              ^
3 errors generated.
gmake[2]: *** [NeoMathEngine/src/CPU/mlas/CMakeFiles/onnxruntime_mlas.dir/build.make:688: NeoMathEngine/src/CPU/mlas/CMakeFiles/onnxruntime_mlas.dir/lib/activate_fp16.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:308: NeoMathEngine/src/CPU/mlas/CMakeFiles/onnxruntime_mlas.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

adding explicit includes should fix that