### PR TITLE
fix for CFastArray

### DIFF
--- a/NeoML/include/NeoML/TraditionalML/SimpleGenerator.h
+++ b/NeoML/include/NeoML/TraditionalML/SimpleGenerator.h
@@ -98,6 +98,7 @@ private:
 		int PrevStep; // the index of the previous step in executedSteps for complex steps; NotFound for simple steps
 		short InitialStepIndex; // the index in the initialSteps array; used to generate next steps
 
+		CStep() = default; // usage in CFastArray requires default constructor
 		CStep( const Quality& zeroQuality );
 		bool IsNull() const { return VariantIndex == 0; }
 	};


### PR DESCRIPTION
to fix this error:
```
error: constructor for 'FObj::CFastArrayBase<NeoML::CSimpleGenerator<Image::CBestSheetGenerator::CInnerLineView>::CStep, 10, FObj::CurrentMemoryManager>' must explicitly initialize the member 'buffer' which does not have a default constructor
   44 |                 CFastArrayBase();
      |                 ^
```